### PR TITLE
Allow getting transactions with info in one request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Listing transactions within time period:
 {'comment': u'N\xe1kup: IKEA CR, BRNO, CZ, dne 17.1.2013, \u010d\xe1stka  2769.00 CZK', 'recipient_message': u'N\xe1kup: IKEA CR, BRNO, CZ, dne 17.1.2013, \u010d\xe1stka  2769.00 CZK', 'user_identifiaction': u'N\xe1kup: IKEA CR, BRNO, CZ, dne 17.1.2013, \u010d\xe1stka  2769.00 CZK', 'currency': 'CZK', 'amount': -2769.0, 'instruction_id': 'XXXXXXXXXX', 'executor': u'Vilém Fusek', 'date': datetime.date(2013, 1, 20), 'type': u'Platba kartou', 'transaction_id': 'XXXXXXXXXX'}
 ```
 
+Getting transactions with account information in one request:
+
+```python
+>>> client.period('2013-01-20', '2013-03-20', with_info=True)
+{'info': {'currency': 'CZK', 'account_number_full': 'XXXXXXXXXX/2010', 'balance': 42.00, 'account_number': 'XXXXXXXXXX', 'bank_code': '2010'}, 'transactions': <generator object _parse_transactions at 0x170c190>}
+```
+
 Listing transactions from single account statement:
 
 ```python

--- a/fiobank.py
+++ b/fiobank.py
@@ -135,22 +135,31 @@ class FioBank(object):
             # generate transaction data
             yield trans
 
+    def _parse_statement(self, data, with_info):
+        if with_info:
+            return {
+                'info': self._parse_info(data),
+                'transactions': self._parse_transactions(data)
+            }
+        else:
+            return self._parse_transactions(data)
+
     def info(self):
         today = date.today()
         data = self._request('periods', from_date=today, to_date=today)
         return self._parse_info(data)
 
-    def period(self, from_date, to_date):
+    def period(self, from_date, to_date, with_info=False):
         data = self._request('periods',
                              from_date=coerce_date(from_date),
                              to_date=coerce_date(to_date))
-        return self._parse_transactions(data)
+        return self._parse_statement(data, with_info)
 
-    def statement(self, year, number):
+    def statement(self, year, number, with_info=False):
         data = self._request('by-id', year=year, number=number)
-        return self._parse_transactions(data)
+        return self._parse_statement(data, with_info)
 
-    def last(self, from_id=None, from_date=None):
+    def last(self, from_id=None, from_date=None, with_info=False):
         assert not (from_id and from_date), "Only one constraint is allowed."
 
         if from_id:
@@ -158,4 +167,4 @@ class FioBank(object):
         elif from_date:
             self._request('set-last-date', from_date=coerce_date(from_date))
 
-        return self._parse_transactions(self._request('last'))
+        return self._parse_statement(self._request('last'), with_info)


### PR DESCRIPTION
This patch allows to read both transactions and the account information in one request. This is useful to avoid the server request rate limit (error 409).
