### PR TITLE
Handle HTTP 409 (conflict) responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fiobank
 
-[![PyPI version](https://badge.fury.io/py/redis-collections.svg)](https://badge.fury.io/py/redis-collections)
+[![PyPI version](https://badge.fury.io/py/fiobank.svg)](https://badge.fury.io/py/fiobank)
 [![Build Status](https://travis-ci.org/honzajavorek/fiobank.svg?branch=master)](https://travis-ci.org/honzajavorek/fiobank)
 
 [Fio Bank API](http://www.fio.cz/bank-services/internetbanking-api) in Python.

--- a/README.md
+++ b/README.md
@@ -49,11 +49,8 @@ Listing latest transactions:
 >>> client.last(from_date='2013-03-01')  # sets cursor to given date and returns following transactions
 ```
 
-## Conflict error 
-[Fio API documentation](http://www.fio.cz/docs/cz/API_Bankovnictvi.pdf) (Section 8.2) states that a single token should be used only once per 30s. Otherwise a HTTP conflict will be returned and `Fiobank.ThrottlingError` will be raised. 
-
-
-For further information [read code](https://github.com/honzajavorek/fiobank/blob/master/fiobank.py).
+## Conflict Error
+[Fio API documentation](http://www.fio.cz/docs/cz/API_Bankovnictvi.pdf) (Section 8.2) states that a single token should be used only once per 30s. Otherwise a HTTP 409 Conflict will be returned and `fiobank.ThrottlingError` will be raised.
 
 ## License: ISC
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Listing latest transactions:
 >>> client.last(from_date='2013-03-01')  # sets cursor to given date and returns following transactions
 ```
 
-For further information [read code](https://github.com/honzajavorek/fiobank/blob/master/fiobank.py).
+## Conflict error 
+[Fio API documentation](http://www.fio.cz/docs/cz/API_Bankovnictvi.pdf) (Section 8.2) states that a single token should be used only once per 30s. Otherwise a HTTP conflict will be returned and `Fiobank.ThrottlingError` will be raised. 
 
+
+For further information [read code](https://github.com/honzajavorek/fiobank/blob/master/fiobank.py).
 
 ## License: ISC
 

--- a/fiobank.py
+++ b/fiobank.py
@@ -54,25 +54,25 @@ class FioBank(object):
 
     # http://www.fio.cz/xsd/IBSchema.xsd
     transaction_schema = {
-        'column22': ('transaction_id', str),
         'column0': ('date', coerce_date),
         'column1': ('amount', float),
-        'column14': ('currency', str),
         'column2': ('account_number', str),
-        'column10': ('account_name', str),
         'column3': ('bank_code', str),
-        'column26': ('bic', str),
-        'column12': ('bank_name', str),
         'column4': ('constant_symbol', str),
         'column5': ('variable_symbol', str),
         'column6': ('specific_symbol', str),
         'column7': ('user_identification', str),
-        'column16': ('recipient_message', str),
         'column8': ('type', str),
         'column9': ('executor', str),
-        'column18': ('specification', str),
-        'column25': ('comment', str),
+        'column10': ('account_name', str),
+        'column12': ('bank_name', str),
+        'column14': ('currency', str),
+        'column16': ('recipient_message', str),
         'column17': ('instruction_id', str),
+        'column18': ('specification', str),
+        'column22': ('transaction_id', str),
+        'column25': ('comment', str),
+        'column26': ('bic', str),
     }
 
     info_schema = {

--- a/fiobank.py
+++ b/fiobank.py
@@ -33,6 +33,14 @@ def sanitize_value(value, convert=None):
     return value
 
 
+class ThrottlingError(Exception):
+    """
+        Throttling error raised when api is being used too fast.
+    """
+    def __str__(self):
+        return 'Token should be used only once per 30s.'
+
+
 class FioBank(object):
 
     base_url = 'https://www.fio.cz/ib_api/rest/'

--- a/fiobank.py
+++ b/fiobank.py
@@ -95,6 +95,9 @@ class FioBank(object):
         url = template.format(token=self.token, **params)
 
         response = requests.get(url)
+        if response.status_code == requests.codes['conflict']:
+            raise ThrottlingError()
+
         response.raise_for_status()
 
         if response.content:

--- a/fiobank.py
+++ b/fiobank.py
@@ -10,7 +10,7 @@ import six
 import requests
 
 
-__all__ = ('FioBank',)
+__all__ = ('FioBank', 'ThrottlingError')
 
 
 str = six.text_type
@@ -34,9 +34,8 @@ def sanitize_value(value, convert=None):
 
 
 class ThrottlingError(Exception):
-    """
-        Throttling error raised when api is being used too fast.
-    """
+    """Throttling error raised when api is being used too fast."""
+
     def __str__(self):
         return 'Token should be used only once per 30s.'
 


### PR DESCRIPTION
Introduces `ThrottlingError` from https://github.com/honzajavorek/fiobank/pull/7 by @Visgean.

- Closes https://github.com/honzajavorek/fiobank/issues/5
- Closes https://github.com/honzajavorek/fiobank/pull/7

Needs test 😐 Hopefully test will be introduced when implementing https://github.com/honzajavorek/fiobank/issues/12.