### PR TITLE
Add support for column27

### DIFF
--- a/fiobank.py
+++ b/fiobank.py
@@ -64,6 +64,7 @@ class FioBank(object):
         'column22': ('transaction_id', str),
         'column25': ('comment', str),
         'column26': ('bic', str),
+        'column27': ('reference', str),
     }
 
     info_schema = {

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -129,7 +129,7 @@ def test_transactions_integration(client, method, args, kwargs):
             'variable_symbol', 'specific_symbol', 'user_identification',
             'recipient_message', 'type', 'executor', 'specification',
             'comment', 'instruction_id', 'account_number_full',
-            'original_amount', 'original_currency',
+            'original_amount', 'original_currency', 'reference',
         ])
 
     assert count > 0


### PR DESCRIPTION
Called "REFERENCE PLATCE" in XSD

Otherwise, the module crashes:

```
  File "/home/nijel/weblate-web/payments/backends.py", line 393, in fetch_payments
    for transaction in client.last(from_date=from_date):
  File "/home/nijel/weblate-web/.venv/lib/python3.7/site-packages/fiobank.py", line 135, in _parse_transactions
    field_name, convert = schema[column_name.lower()]
KeyError: 'column27'
```