### PR TITLE
chore: test against Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.0.0 (master)
 ### Breaking
-* Dropped support for Python 3.6 and 3.7
+* Dropped support for Python 3.6, 3.7 and 3.8
 
 ### Fix
 * Added deprecation warning for decimal=False
@@ -11,6 +11,7 @@
 * Re-introduced CI tests
 * Re-introduced Dependabot
 * Updated .gitignore
+* Added support for Python 3.13
 
 ## v3.1.0 (2024-06-13)
 ### Features


### PR DESCRIPTION
Built on top of https://github.com/honzajavorek/fiobank/pull/39

Also drop Python 3.8 as described in #35.
