### PR TITLE
docs: fix build status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ license <https://en.wikipedia.org/wiki/ISC_license>`__.
 
 .. |PyPI version| image:: https://badge.fury.io/py/fiobank.svg
    :target: https://badge.fury.io/py/fiobank
-.. |Build Status| image:: https://travis-ci.org/honzajavorek/fiobank.svg?branch=master
-   :target: https://travis-ci.org/honzajavorek/fiobank
+.. |Build Status| image:: https://github.com/honzajavorek/fiobank/actions/workflows/test.yml/badge.svg
+   :target: https://github.com/honzajavorek/fiobank/actions/workflows/test.yml
 .. |Test Coverage| image:: https://coveralls.io/repos/github/honzajavorek/fiobank/badge.svg?branch=master
    :target: https://coveralls.io/github/honzajavorek/fiobank?branch=master


### PR DESCRIPTION
The CI is now using GitHub so adjust the badge URLs.