### PR TITLE
feat: automate release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Build
+        run: uv build
+
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'WeblateOrg/language-data'
+        run: uv publish --trusted-publishing always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,5 +17,5 @@ jobs:
         run: uv build
 
       - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'WeblateOrg/language-data'
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'honzajavorek/fiobank'
         run: uv publish --trusted-publishing always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: astral-sh/setup-uv@v3
+
       - name: Install
-        run: pip install -e .[tests]
+        run: uv pip install --system -e .[tests]
 
       - name: Test
         run: pytest


### PR DESCRIPTION
I see in #35 that you are looking for release automation, this is my suggestion for that.
    
- use uv to install dependencies for faster CI
- add new workflow to build and publish releases on tags

It will need for you to configure trusted publishing on PyPI, see https://docs.pypi.org/trusted-publishers/.

Built on top of https://github.com/honzajavorek/fiobank/pull/39 to avoid not needed test failures.