### PR TITLE
chore: remove object inheritance

### DIFF
--- a/fiobank.py
+++ b/fiobank.py
@@ -48,7 +48,7 @@ class ThrottlingError(Exception):
         return "Token can be used only once per 30s"
 
 
-class FioBank(object):
+class FioBank:
     base_url = "https://fioapi.fio.cz/v1/rest/"
 
     actions = {


### PR DESCRIPTION
It is not needed in Python 3.