### PR TITLE
chore: remove unused NOQA tag

### DIFF
--- a/fiobank.py
+++ b/fiobank.py
@@ -147,7 +147,7 @@ class FioBank(object):
     def _parse_transactions(self, data: dict) -> Generator[dict, None, None]:
         schema = self.transaction_schema
         try:
-            entries = data["accountStatement"]["transactionList"]["transaction"]  # NOQA
+            entries = data["accountStatement"]["transactionList"]["transaction"]
         except TypeError:
             entries = []
 


### PR DESCRIPTION
Probably needed for a different linter.