### PR TITLE
fix: add token validation to prevent hanging with None/empty tokens

### DIFF
--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -32,6 +32,8 @@ class FioBank:
     _amount_re = re.compile(r"\-?\d+(\.\d+)? [A-Z]{3}")
 
     def __init__(self, token: str, *, decimal: bool = False):
+        if not token:
+            raise ValueError("Token cannot be None or empty")
         self.token = token
 
         if decimal:

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -32,9 +32,9 @@ class FioBank:
     _amount_re = re.compile(r"\-?\d+(\.\d+)? [A-Z]{3}")
 
     def __init__(self, token: str, *, decimal: bool = False):
-        if not token:
+        if not isinstance(token, str) or not token.strip():
             raise ValueError("Token cannot be None or empty")
-        self.token = token
+        self.token = token.strip()
 
         if decimal:
             self.float_type = Decimal

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -247,12 +247,10 @@ def test_statement(transactions_json):
         stub.assert_called_once_with("by-id", year=2016, number=308)
 
 
-def test_invalid_token():
+@pytest.mark.parametrize("bad_token", [None, "", "   "])
+def test_invalid_token(bad_token):
     with pytest.raises(ValueError, match="Token cannot be None or empty"):
-        FioBank(token=None)
-
-    with pytest.raises(ValueError, match="Token cannot be None or empty"):
-        FioBank(token="")
+        FioBank(token=bad_token)
 
 
 def test_last_conflicting_params():

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -247,6 +247,14 @@ def test_statement(transactions_json):
         stub.assert_called_once_with("by-id", year=2016, number=308)
 
 
+def test_invalid_token():
+    with pytest.raises(ValueError, match="Token cannot be None or empty"):
+        FioBank(token=None)
+
+    with pytest.raises(ValueError, match="Token cannot be None or empty"):
+        FioBank(token="")
+
+
 def test_last_conflicting_params():
     client = FioBank("...")
     with pytest.raises(ValueError):


### PR DESCRIPTION
Adds validation in `FioBank.__init__()` to raise `ValueError` when token is `None` or empty string

Fixes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initialization now enforces that authentication tokens are non-empty; a clear error is raised if a token is missing or blank.

* **Tests**
  * Added parameterized tests covering invalid token inputs to verify the new validation and error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->