### PR TITLE
Use build-and-inspect-python-package in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,28 @@ on:
   pull_request:
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/fiobank
-    permissions:
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Build and inspect package
+        uses: hynek/build-and-inspect-python-package@v2
+
+  smoke-test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
 
       - uses: astral-sh/setup-uv@v7
-
-      - name: Build
-        run: uv build
 
       - name: Smoke Test
         run: |
@@ -28,6 +35,23 @@ jobs:
           .smoketest/bin/python -c 'from fiobank import FioBank'
           rm -r .smoketest
 
+  publish:
+    needs: smoke-test
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'honzajavorek/fiobank'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fiobank
+    permissions:
+      id-token: write
+    steps:
+      - name: Download built package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - uses: astral-sh/setup-uv@v7
+
       - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'honzajavorek/fiobank'
         run: uv publish --trusted-publishing always


### PR DESCRIPTION
Closes #57.

Wires [`hynek/build-and-inspect-python-package`](https://github.com/hynek/build-and-inspect-python-package) into the release pipeline and restructures the workflow around a single shared build artifact.

## What changed

The single `release` job is split into three jobs that share the built distribution:

- **`build`** — runs `hynek/build-and-inspect-python-package@v2`. Builds the wheel + sdist reproducibly (`fetch-depth: 0` so `SOURCE_DATE_EPOCH` picks up the real commit timestamp), lints the wheel with `check-wheel-contents`, validates the PyPI README with `twine`, and prints the dist tree + metadata. Uploads the result as the `Packages` artifact.
- **`smoke-test`** — downloads that artifact and keeps the existing install-into-a-venv + `from fiobank import FioBank` check. baipp does not install/import, so this stays — but it now tests the exact artifact that will be published instead of rebuilding it.
- **`publish`** — downloads the same artifact and runs `uv publish` (unchanged tag/repo/trusted-publishing conditions).

## Why

baipp adds wheel-content linting and PyPI README validation that the pipeline had no coverage for, "for free" — while the import smoke test is retained because baipp does not install or import the package. Building once and sharing the artifact means the smoke test and the PyPI upload verify the very same distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgnCb2ed1sRwCkaTQqNPup)_