### PR TITLE
Add last_statement() for the lastStatement REST endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,20 @@ Listing transactions from a single account statement:
 
     >>> client.statement(2013, 1)  # 1 is January only by coincidence - arguments mean 'first statement of 2013'
 
+Finding the last (most recent) account statement:
+
+.. code:: python
+
+    >>> client.last_statement()  # (year, number) of the last statement, e.g. (2013, 12)
+    >>> client.last_statement(year=2013)  # last statement number for a given year
+    >>> client.last_statement(year=2000)  # None when there's no statement for the year
+
+The returned ``(year, number)`` pair can be passed straight to ``statement()``:
+
+.. code:: python
+
+    >>> client.statement(*client.last_statement())
+
 Listing the latest transactions:
 
 .. code:: python

--- a/README.rst
+++ b/README.rst
@@ -77,19 +77,17 @@ Listing transactions from a single account statement:
 
     >>> client.statement(2013, 1)  # 1 is January only by coincidence - arguments mean 'first statement of 2013'
 
-Finding the last (most recent) account statement:
+Listing transactions from the last (most recent) account statement:
 
 .. code:: python
 
-    >>> client.last_statement()  # (year, number) of the last statement, e.g. (2013, 12)
-    >>> client.last_statement(year=2013)  # last statement number for a given year
-    >>> client.last_statement(year=2000)  # None when there's no statement for the year
+    >>> client.last_statement()  # transactions of the last statement
+    >>> client.last_statement(2013)  # transactions of the last statement of 2013
 
-The returned ``(year, number)`` pair can be passed straight to ``statement()``:
-
-.. code:: python
-
-    >>> client.statement(*client.last_statement())
+This resolves the most recent statement number (via Fio's undocumented
+``lastStatement`` endpoint, also used by the official ``api-plus`` application)
+and returns its transactions, just like ``statement()``. It raises
+``ValueError`` when there's no statement for the given year.
 
 Listing the latest transactions:
 

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Listing transactions from the last (most recent) account statement:
     >>> client.last_statement(2013)  # transactions of the last statement of 2013
 
 This resolves the most recent statement number (via Fio's undocumented
-``lastStatement`` endpoint, also used by the official ``api-plus`` application)
+``lastStatement`` endpoint, also used by the official Fio API Plus application)
 and returns its transactions, just like ``statement()``. It raises
 ``ValueError`` when there's no statement for the given year.
 

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -28,6 +28,7 @@ class FioBank:
         "last": "last/{token}/transactions.json",
         "set-last-id": "set-last-id/{token}/{from_id}/",
         "set-last-date": "set-last-date/{token}/{from_date}/",
+        "last-statement": "lastStatement/{token}/statement",
     }
 
     _amount_re = re.compile(r"\-?\d+(\.\d+)? [A-Z]{3}")
@@ -72,11 +73,8 @@ class FioBank:
         stop=stop_after_attempt(3),
         wait=wait_random_exponential(max=2 * 60),
     )
-    def _request(self, action: str, **params) -> dict | None:
-        url_template = self.base_url + self.actions[action]
-        url = url_template.format(token=self.token, **params)
-
-        response = requests.get(url)
+    def _get(self, url: str, params: dict | None = None) -> requests.Response:
+        response = requests.get(url, params=params)
         if response.status_code == requests.codes["conflict"]:
             raise ThrottlingError()
 
@@ -100,6 +98,13 @@ class FioBank:
 
             raise requests.HTTPError(sanitized_msg, response=response)
 
+        return response
+
+    def _request(self, action: str, **params) -> dict | None:
+        url_template = self.base_url + self.actions[action]
+        url = url_template.format(token=self.token, **params)
+
+        response = self._get(url)
         if response.content:
             return response.json(parse_float=self.float_type)
         return None
@@ -208,3 +213,18 @@ class FioBank:
     ) -> tuple[dict, Generator[dict]]:
         data = self._fetch_last(from_id, from_date)
         return (self._parse_info(data), self._parse_transactions(data))
+
+    def last_statement(self, year: int | None = None) -> tuple[int, int] | None:
+        # This endpoint isn't part of the official REST API documentation, but
+        # it's used by the official Fio 'api-plus' Java application. It returns
+        # the year and sequence number of the last statement, e.g. "2017,12",
+        # or "null,null" when there's no statement for the given year. The
+        # returned sequence number can be passed to 'statement()'.
+        url = self.base_url + self.actions["last-statement"].format(token=self.token)
+        params = {"year": year} if year is not None else None
+
+        response = self._get(url, params=params)
+        year_value, _, number_value = response.text.strip().partition(",")
+        if year_value == "null" or not number_value:
+            return None
+        return (int(year_value), int(number_value))

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -214,12 +214,11 @@ class FioBank:
         data = self._fetch_last(from_id, from_date)
         return (self._parse_info(data), self._parse_transactions(data))
 
-    def last_statement(self, year: int | None = None) -> tuple[int, int] | None:
+    def _last_statement_number(self, year: int | None = None) -> tuple[int, int] | None:
         # This endpoint isn't part of the official REST API documentation, but
         # it's used by the official Fio 'api-plus' Java application. It returns
         # the year and sequence number of the last statement, e.g. "2017,12",
-        # or "null,null" when there's no statement for the given year. The
-        # returned sequence number can be passed to 'statement()'.
+        # or "null,null" when there's no statement for the given year.
         url = self.base_url + self.actions["last-statement"].format(token=self.token)
         params = {"year": year} if year is not None else None
 
@@ -228,3 +227,9 @@ class FioBank:
         if year_value == "null" or not number_value:
             return None
         return (int(year_value), int(number_value))
+
+    def last_statement(self, year: int | None = None) -> Generator[dict]:
+        numbering = self._last_statement_number(year)
+        if numbering is None:
+            raise ValueError("No data available")
+        return self.statement(*numbering)

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -22,6 +22,10 @@ from .utils import coerce_date
 class FioBank:
     base_url = "https://fioapi.fio.cz/v1/rest/"
 
+    # Seconds to wait for the API before giving up, so an unresponsive
+    # server can't hang the caller indefinitely.
+    request_timeout = 60
+
     actions = {
         "periods": "periods/{token}/{from_date}/{to_date}/transactions.json",
         "by-id": "by-id/{token}/{year}/{number}/transactions.json",
@@ -74,7 +78,7 @@ class FioBank:
         wait=wait_random_exponential(max=2 * 60),
     )
     def _get(self, url: str, params: dict | None = None) -> requests.Response:
-        response = requests.get(url, params=params)
+        response = requests.get(url, params=params, timeout=self.request_timeout)
         if response.status_code == requests.codes["conflict"]:
             raise ThrottlingError()
 

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -77,7 +77,7 @@ class FioBank:
         stop=stop_after_attempt(3),
         wait=wait_random_exponential(max=2 * 60),
     )
-    def _get(self, url: str, params: dict | None = None) -> requests.Response:
+    def _request(self, url: str, params: dict | None = None) -> requests.Response:
         response = requests.get(url, params=params, timeout=self.request_timeout)
         if response.status_code == requests.codes["conflict"]:
             raise ThrottlingError()
@@ -104,11 +104,11 @@ class FioBank:
 
         return response
 
-    def _request(self, action: str, **params) -> dict | None:
+    def _request_json(self, action: str, **params) -> dict | None:
         url_template = self.base_url + self.actions[action]
         url = url_template.format(token=self.token, **params)
 
-        response = self._get(url)
+        response = self._request(url)
         if response.content:
             return response.json(parse_float=self.float_type)
         return None
@@ -161,14 +161,14 @@ class FioBank:
 
     def info(self) -> dict:
         today = date.today()
-        if data := self._request("periods", from_date=today, to_date=today):
+        if data := self._request_json("periods", from_date=today, to_date=today):
             return self._parse_info(data)
         raise ValueError("No data available")
 
     def _fetch_period(
         self, from_date: str | date | datetime, to_date: str | date | datetime
     ) -> dict:
-        if data := self._request(
+        if data := self._request_json(
             "periods", from_date=coerce_date(from_date), to_date=coerce_date(to_date)
         ):
             return data
@@ -188,7 +188,7 @@ class FioBank:
         raise ValueError("No data available")
 
     def statement(self, year: int, number: int) -> Generator[dict]:
-        if data := self._request("by-id", year=year, number=number):
+        if data := self._request_json("by-id", year=year, number=number):
             return self._parse_transactions(data)
         raise ValueError("No data available")
 
@@ -199,11 +199,11 @@ class FioBank:
             raise ValueError("Only one constraint is allowed.")
 
         if from_id:
-            self._request("set-last-id", from_id=from_id)
+            self._request_json("set-last-id", from_id=from_id)
         elif from_date:
-            self._request("set-last-date", from_date=coerce_date(from_date))
+            self._request_json("set-last-date", from_date=coerce_date(from_date))
 
-        if data := self._request("last"):
+        if data := self._request_json("last"):
             return data
         raise ValueError("No data available")
 
@@ -219,21 +219,16 @@ class FioBank:
         return (self._parse_info(data), self._parse_transactions(data))
 
     def _last_statement_number(self, year: int | None = None) -> tuple[int, int] | None:
-        # This endpoint isn't part of the official REST API documentation, but
-        # it's used by the official Fio 'api-plus' Java application. It returns
-        # the year and sequence number of the last statement, e.g. "2017,12",
-        # or "null,null" when there's no statement for the given year.
         url = self.base_url + self.actions["last-statement"].format(token=self.token)
         params = {"year": year} if year is not None else None
 
-        response = self._get(url, params=params)
+        response = self._request(url, params=params)
         year_value, _, number_value = response.text.strip().partition(",")
         if year_value == "null" or not number_value:
             return None
         return (int(year_value), int(number_value))
 
     def last_statement(self, year: int | None = None) -> Generator[dict]:
-        numbering = self._last_statement_number(year)
-        if numbering is None:
-            raise ValueError("No data available")
-        return self.statement(*numbering)
+        if numbering := self._last_statement_number(year):
+            return self.statement(*numbering)
+        raise ValueError("No data available")

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -471,32 +471,64 @@ def test_transactions_parse_no_account_number_full(transactions_json):
     assert sdk_transaction["account_number_full"] is None
 
 
-def test_last_statement(token: str):
+def test_last_statement(token: str, transactions_text: str):
     with responses.RequestsMock() as resps:
-        url = FioBank.base_url + f"lastStatement/{token}/statement"
-        resps.add(responses.GET, url, body="2017,12")
+        resps.add(
+            responses.GET,
+            FioBank.base_url + f"lastStatement/{token}/statement",
+            body="2017,12",
+        )
+        resps.add(
+            responses.GET,
+            re.compile(
+                re.escape(FioBank.base_url)
+                + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
+            ),
+            body=transactions_text,
+        )
         client = FioBank(token, decimal=True)
 
-        assert client.last_statement() == (2017, 12)
+        transactions = list(client.last_statement())
+
+        assert len(transactions) > 0
+        # the last statement (2017/12) is fetched via the by-id endpoint
+        assert f"by-id/{token}/2017/12/transactions.json" in resps.calls[1].request.url
 
 
-def test_last_statement_year(token: str):
+def test_last_statement_year(token: str, transactions_text: str):
     with responses.RequestsMock() as resps:
-        url = FioBank.base_url + f"lastStatement/{token}/statement"
-        resps.add(responses.GET, url, body="2017,12")
+        resps.add(
+            responses.GET,
+            FioBank.base_url + f"lastStatement/{token}/statement",
+            body="2016,3",
+        )
+        resps.add(
+            responses.GET,
+            re.compile(
+                re.escape(FioBank.base_url)
+                + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
+            ),
+            body=transactions_text,
+        )
         client = FioBank(token, decimal=True)
 
-        assert client.last_statement(year=2017) == (2017, 12)
-        assert resps.calls[0].request.params == {"year": "2017"}
+        list(client.last_statement(2016))
+
+        assert resps.calls[0].request.params == {"year": "2016"}
+        assert f"by-id/{token}/2016/3/transactions.json" in resps.calls[1].request.url
 
 
 def test_last_statement_none(token: str):
     with responses.RequestsMock() as resps:
-        url = FioBank.base_url + f"lastStatement/{token}/statement"
-        resps.add(responses.GET, url, body="null,null")
+        resps.add(
+            responses.GET,
+            FioBank.base_url + f"lastStatement/{token}/statement",
+            body="null,null",
+        )
         client = FioBank(token, decimal=True)
 
-        assert client.last_statement(year=2000) is None
+        with pytest.raises(ValueError, match="No data available"):
+            client.last_statement(2000)
 
 
 def test_409_conflict(token: str, transactions_text: str):

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -471,6 +471,34 @@ def test_transactions_parse_no_account_number_full(transactions_json):
     assert sdk_transaction["account_number_full"] is None
 
 
+def test_last_statement(token: str):
+    with responses.RequestsMock() as resps:
+        url = FioBank.base_url + f"lastStatement/{token}/statement"
+        resps.add(responses.GET, url, body="2017,12")
+        client = FioBank(token, decimal=True)
+
+        assert client.last_statement() == (2017, 12)
+
+
+def test_last_statement_year(token: str):
+    with responses.RequestsMock() as resps:
+        url = FioBank.base_url + f"lastStatement/{token}/statement"
+        resps.add(responses.GET, url, body="2017,12")
+        client = FioBank(token, decimal=True)
+
+        assert client.last_statement(year=2017) == (2017, 12)
+        assert resps.calls[0].request.params == {"year": "2017"}
+
+
+def test_last_statement_none(token: str):
+    with responses.RequestsMock() as resps:
+        url = FioBank.base_url + f"lastStatement/{token}/statement"
+        resps.add(responses.GET, url, body="null,null")
+        client = FioBank(token, decimal=True)
+
+        assert client.last_statement(year=2000) is None
+
+
 def test_409_conflict(token: str, transactions_text: str):
     with responses.RequestsMock(registry=OrderedRegistry) as resps:
         url = re.compile(

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -89,7 +89,9 @@ def test_info_uses_today(transactions_json: dict):
     client = FioBank("...")
     today = date.today()
 
-    with mock.patch.object(client, "_request", return_value=transactions_json) as stub:
+    with mock.patch.object(
+        client, "_request_json", return_value=transactions_json
+    ) as stub:
         client.info()
         stub.assert_called_once_with("periods", from_date=today, to_date=today)
 
@@ -219,7 +221,7 @@ def test_period_coerces_date(transactions_json):
     to_date = "2016-08-30T11:45:38"
 
     options = {"return_value": transactions_json}
-    with mock.patch.object(client, "_request", **options) as stub:
+    with mock.patch.object(client, "_request_json", **options) as stub:
         client.period(from_date, to_date)
         stub.assert_called_once_with(
             "periods", from_date=date(2016, 8, 4), to_date=date(2016, 8, 30)
@@ -230,7 +232,7 @@ def test_statement(transactions_json):
     client = FioBank("...")
 
     options = {"return_value": transactions_json}
-    with mock.patch.object(client, "_request", **options) as stub:
+    with mock.patch.object(client, "_request_json", **options) as stub:
         client.statement(2016, 308)
         stub.assert_called_once_with("by-id", year=2016, number=308)
 
@@ -251,7 +253,7 @@ def test_last_from_id(transactions_json):
     client = FioBank("...")
 
     options = {"return_value": transactions_json}
-    with mock.patch.object(client, "_request", **options) as stub:
+    with mock.patch.object(client, "_request_json", **options) as stub:
         client.last(from_id=308)
         stub.assert_has_calls(
             [
@@ -266,7 +268,7 @@ def test_last_from_date(transactions_json, test_input):
     client = FioBank("...")
 
     options = {"return_value": transactions_json}
-    with mock.patch.object(client, "_request", **options) as stub:
+    with mock.patch.object(client, "_request_json", **options) as stub:
         client.last(from_date=test_input)
         stub.assert_has_calls(
             [


### PR DESCRIPTION
Closes #20.

## What

Adds `FioBank.last_statement()`, exposing the `lastStatement` REST endpoint. This endpoint isn't part of Fio's official API documentation, but it's used by Fio's official `api-plus` Java application. It reports the year and sequence number of the last account statement.

## Behaviour

`last_statement()` returns the transactions of the last statement, mirroring the existing `statement()` / `period()` / `last()` methods — callers get transactions, not bookkeeping values:

```python
>>> client.last_statement()      # transactions of the last statement
>>> client.last_statement(2013)  # transactions of the last statement of 2013
```

Under the hood it resolves the most recent statement number for the given year via the `lastStatement` endpoint, then fetches that statement's transactions through `statement()`. When there's no statement for the year (Fio's `null,null` response), it raises `ValueError("No data available")`, consistent with how the other methods signal empty results.

## Implementation notes

- The `lastStatement` endpoint replies with plain text (`2017,12`, or `null,null`) rather than JSON. To handle that, the shared HTTP / retry / token-sanitizing logic was extracted from `_request()` into a new `_get()` helper. `_request()` still parses JSON as before; the new private `_last_statement_number()` helper reuses `_get()` and parses the text. This keeps 409 throttling retries and token redaction consistent across both paths.
- Added a configurable class-level `request_timeout` (default 60s), applied in `_get()`, so an unresponsive API can't hang the caller indefinitely. This now covers every request the library makes.
- Added tests covering the success case, the `year` query parameter, and the `null,null` → `ValueError` case.
- Documented the new method in `README.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ypX7EsyTSoMzTsgYWTtiX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `last_statement()` to retrieve transactions from the latest statement, optionally for a specified year.
  * Provides a clear error when no statement data is available.
  * Added a 60-second timeout for API requests.

* **Documentation**
  * Clarified the name of the official Fio API Plus application in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->