### PR TITLE
Make the HTTP client pluggable via transports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,8 +130,8 @@ By default ``FioBank`` talks to the API with `httpx
 <https://www.python-httpx.org/>`_ (``httpx.Client``) and ``AsyncFioBank``
 with ``httpx.AsyncClient``. Both accept a ``transport=`` argument, so you can
 plug in any HTTP client -- ``aiohttp``, ``urllib``, a caching or proxying
-layer, or a fake for tests. A transport does exactly one thing: GET a URL and
-return a status code plus the raw body bytes.
+layer, or a fake for tests. A transport does two things: GET a URL (returning
+a status code plus the raw body bytes) and ``close()`` itself.
 
 .. code:: python
 
@@ -143,21 +143,23 @@ return a status code plus the raw body bytes.
     ...         self.timeout = timeout
     ...         self.session = requests.Session()
     ...
-    ...     def get(self, url, params=None):
-    ...         r = self.session.get(url, params=params, timeout=self.timeout)
+    ...     def get(self, url):
+    ...         r = self.session.get(url, timeout=self.timeout)
     ...         return Response(r.status_code, r.content)
+    ...
+    ...     def close(self):
+    ...         self.session.close()
     ...
     >>> client = FioBank(token='...', decimal=True, transport=RequestsTransport())
 
 The synchronous ``Transport`` and asynchronous ``AsyncTransport`` protocols
-(both exported from ``fiobank``) describe the single ``get()`` method a custom
-transport needs to implement.
+(both exported from ``fiobank``) describe the ``get()`` and ``close()`` /
+``aclose()`` methods a custom transport needs to implement.
 
 The default transports keep a persistent HTTP client (a connection pool) open.
 Use the client as a context manager -- or call ``close()`` / ``await
 aclose()`` -- to release it deterministically instead of waiting for garbage
-collection. An HTTP client you inject yourself stays under your control and is
-never closed for you.
+collection.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,52 @@ Getting the latest transactions with account information in one request:
         <generator object _parse_transactions at 0x170c190>
    )
 
+Async
+-----
+
+``AsyncFioBank`` mirrors ``FioBank`` method for method, only the I/O is
+awaited. Parsing stays synchronous, so the transaction generators are the
+same in both variants -- you just ``await`` the call to get them:
+
+.. code:: python
+
+    >>> from fiobank import AsyncFioBank
+    >>> client = AsyncFioBank(token='...', decimal=True)
+    >>> info = await client.info()
+    >>> transactions = await client.period('2013-01-20', '2013-03-20')
+    >>> for transaction in transactions:
+    ...     ...
+
+HTTP client
+-----------
+
+By default ``FioBank`` talks to the API with `httpx
+<https://www.python-httpx.org/>`_ (``httpx.Client``) and ``AsyncFioBank``
+with ``httpx.AsyncClient``. Both accept a ``transport=`` argument, so you can
+plug in any HTTP client -- ``aiohttp``, ``urllib``, a caching or proxying
+layer, or a fake for tests. A transport does exactly one thing: GET a URL and
+return a status code plus the raw body bytes.
+
+.. code:: python
+
+    >>> from fiobank import FioBank, Response
+    >>>
+    >>> class RequestsTransport:
+    ...     def __init__(self, timeout=60):
+    ...         import requests
+    ...         self.timeout = timeout
+    ...         self.session = requests.Session()
+    ...
+    ...     def get(self, url, params=None):
+    ...         r = self.session.get(url, params=params, timeout=self.timeout)
+    ...         return Response(r.status_code, r.content)
+    ...
+    >>> client = FioBank(token='...', decimal=True, transport=RequestsTransport())
+
+The synchronous ``Transport`` and asynchronous ``AsyncTransport`` protocols
+(both exported from ``fiobank``) describe the single ``get()`` method a custom
+transport needs to implement.
+
 Conflict Error
 --------------
 
@@ -117,6 +163,14 @@ Conflict Error
 The client automatically retries throttling errors up to 3 times with
 exponential backoff. If all attempts fail,
 ``fiobank.ThrottlingError`` will be raised.
+
+HTTP Errors
+-----------
+
+Any other non-2xx response raises ``fiobank.HTTPError`` (with the API token
+redacted from the message). This is transport-independent -- earlier versions
+leaked ``requests.HTTPError``, which is exactly what made the HTTP client
+impossible to swap out.
 
 Notes
 -----

--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,20 @@ The synchronous ``Transport`` and asynchronous ``AsyncTransport`` protocols
 (both exported from ``fiobank``) describe the single ``get()`` method a custom
 transport needs to implement.
 
+The default transports keep a persistent HTTP client (a connection pool) open.
+Use the client as a context manager -- or call ``close()`` / ``await
+aclose()`` -- to release it deterministically instead of waiting for garbage
+collection. An HTTP client you inject yourself stays under your control and is
+never closed for you.
+
+.. code:: python
+
+    >>> with FioBank(token='...', decimal=True) as client:
+    ...     info = client.info()
+    ...
+    >>> async with AsyncFioBank(token='...', decimal=True) as client:
+    ...     info = await client.info()
+
 Conflict Error
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest-ruff>=0.4.1",
     "pytest>=7.2.1",
-    "respx>=0.21.1",
     "ruff>=0.8.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ authors = [{name = "Honza Javorek", email = "mail@honzajavorek.cz"}]
 license = {text = "ISC"}
 requires-python = "<4.0,>=3.9"
 dependencies = [
+    "httpx>=0.28",
     "pydantic>=2.0.0",
-    "requests<3.0.0,>=2.28.2",
     "tenacity>=9.0.0",
 ]
 classifiers = [
@@ -27,10 +27,11 @@ repository = "https://github.com/honzajavorek/fiobank"
 [dependency-groups]
 dev = [
     "mock>=5.0.1",
+    "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "pytest-ruff>=0.4.1",
     "pytest>=7.2.1",
-    "responses>=0.22.0",
+    "respx>=0.21.1",
     "ruff>=0.8.4",
 ]
 
@@ -38,6 +39,7 @@ dev = [
 pythonpath = ["."]
 testpaths = "tests"
 norecursedirs = "env venv .git"
+asyncio_mode = "auto"
 addopts = "--ff --ruff --ruff-format --cov=fiobank --cov-report=term-missing:skip-covered --cov-context=test"
 filterwarnings = ["ignore:Using float for money can cause inaccuracies:DeprecationWarning"]
 

--- a/src/fiobank/__init__.py
+++ b/src/fiobank/__init__.py
@@ -1,5 +1,22 @@
-from .exceptions import ThrottlingError
-from .fiobank import FioBank
+from .exceptions import HTTPError, ThrottlingError
+from .fiobank import AsyncFioBank, FioBank
+from .transports import (
+    AsyncTransport,
+    HTTPXAsyncTransport,
+    HTTPXTransport,
+    Response,
+    Transport,
+)
 
 
-__all__ = ("FioBank", "ThrottlingError")
+__all__ = (
+    "AsyncFioBank",
+    "AsyncTransport",
+    "FioBank",
+    "HTTPError",
+    "HTTPXAsyncTransport",
+    "HTTPXTransport",
+    "Response",
+    "ThrottlingError",
+    "Transport",
+)

--- a/src/fiobank/exceptions.py
+++ b/src/fiobank/exceptions.py
@@ -11,9 +11,8 @@ class ThrottlingError(Exception):
 class HTTPError(Exception):
     """Raised for non-2xx HTTP responses.
 
-    Replaces the ``requests.HTTPError`` that older versions leaked. The
-    message has the API token redacted; ``status_code`` carries the HTTP
-    status of the offending response.
+    The message has the API token redacted; ``status_code`` carries the
+    HTTP status of the offending response.
     """
 
     def __init__(self, message: str, *, status_code: int | None = None):

--- a/src/fiobank/exceptions.py
+++ b/src/fiobank/exceptions.py
@@ -6,3 +6,16 @@ class ThrottlingError(Exception):
 
     def __str__(self) -> str:
         return "Token can be used only once per 30s"
+
+
+class HTTPError(Exception):
+    """Raised for non-2xx HTTP responses.
+
+    Replaces the ``requests.HTTPError`` that older versions leaked. The
+    message has the API token redacted; ``status_code`` carries the HTTP
+    status of the offending response.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import json
 import re
 import warnings
 from collections.abc import Generator
 from datetime import date, datetime
 from decimal import Decimal
 
-import requests
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -14,12 +14,31 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from .exceptions import ThrottlingError
+from .exceptions import HTTPError, ThrottlingError
 from .models import Info, Transaction
+from .transports import (
+    AsyncTransport,
+    HTTPXAsyncTransport,
+    HTTPXTransport,
+    Response,
+    Transport,
+)
 from .utils import coerce_date
 
 
-class FioBank:
+DEFAULT_BASE_URL = "https://fioapi.fio.cz/v1/rest/"
+
+
+class FioBankBase:
+    """Transport-agnostic core shared by :class:`FioBank` and
+    :class:`AsyncFioBank`.
+
+    It knows how to build URLs, interpret HTTP responses, sanitize the token
+    out of error messages, decode JSON, and turn Fio's payloads into plain
+    dictionaries. None of that touches the network, so both the synchronous
+    and asynchronous clients reuse it unchanged.
+    """
+
     _actions = {
         "periods": "periods/{token}/{from_date}/{to_date}/transactions.json",
         "by-id": "by-id/{token}/{year}/{number}/transactions.json",
@@ -36,7 +55,7 @@ class FioBank:
         token: str,
         *,
         decimal: bool = False,
-        base_url: str = "https://fioapi.fio.cz/v1/rest/",
+        base_url: str = DEFAULT_BASE_URL,
         request_timeout: float = 60,
     ):
         if not isinstance(token, str) or not token.strip():
@@ -75,47 +94,33 @@ class FioBank:
             "'fiobank.models.Info' Pydantic model."
         )
 
-    @retry(
-        retry=retry_if_exception_type(ThrottlingError),
-        reraise=True,
-        stop=stop_after_attempt(3),
-        wait=wait_random_exponential(max=2 * 60),
-    )
-    def _request(self, url: str, params: dict | None = None) -> requests.Response:
-        response = requests.get(url, params=params, timeout=self.request_timeout)
-        if response.status_code == requests.codes["conflict"]:
-            raise ThrottlingError()
-
-        # Handle all other HTTP errors with token sanitization and response body
-        try:
-            response.raise_for_status()
-        except requests.HTTPError as e:
-            # Get the original error message and sanitize token
-            sanitized_msg = str(e).replace(self.token, "***TOKEN***")
-
-            # Try to get response body and sanitize it too
-            try:
-                response_body = response.text
-                if response_body:
-                    # Sanitize token from response body as well
-                    sanitized_body = response_body.replace(self.token, "***TOKEN***")
-                    # Append response body to the error message
-                    sanitized_msg = f"{sanitized_msg}. Response body: {sanitized_body}"
-            except Exception:
-                pass  # If we can't get response body, just use the original error
-
-            raise requests.HTTPError(sanitized_msg, response=response)
-
-        return response
-
-    def _request_json(self, action: str, **params) -> dict | None:
+    def _build_url(self, action: str, **params) -> str:
         url_template = self.base_url + self._actions[action]
-        url = url_template.format(token=self.token, **params)
+        return url_template.format(token=self.token, **params)
 
-        response = self._request(url)
+    def _sanitize(self, text: str) -> str:
+        return text.replace(self.token, "***TOKEN***")
+
+    def _check(self, url: str, response: Response) -> None:
+        if response.status_code == 409:
+            raise ThrottlingError()
+        if response.status_code >= 400:
+            message = f"HTTP {response.status_code} for {url}"
+            body = response.text
+            if body:
+                message = f"{message}. Response body: {body}"
+            raise HTTPError(self._sanitize(message), status_code=response.status_code)
+
+    def _parse_json(self, response: Response) -> dict | None:
         if response.content:
-            return response.json(parse_float=self.float_type)
+            return json.loads(response.text, parse_float=self.float_type)
         return None
+
+    def _parse_statement_number(self, response: Response) -> tuple[int, int] | None:
+        year_value, _, number_value = response.text.strip().partition(",")
+        if year_value == "null" or not number_value:
+            return None
+        return (int(year_value), int(number_value))
 
     def _parse_info(self, data: dict) -> dict:
         info = Info.model_validate(
@@ -162,6 +167,40 @@ class FioBank:
             account_number_full = None
 
         obj["account_number_full"] = account_number_full
+
+
+class FioBank(FioBankBase):
+    def __init__(
+        self,
+        token: str,
+        *,
+        decimal: bool = False,
+        base_url: str = DEFAULT_BASE_URL,
+        request_timeout: float = 60,
+        transport: Transport | None = None,
+    ):
+        super().__init__(
+            token,
+            decimal=decimal,
+            base_url=base_url,
+            request_timeout=request_timeout,
+        )
+        self.transport: Transport = transport or HTTPXTransport(timeout=request_timeout)
+
+    @retry(
+        retry=retry_if_exception_type(ThrottlingError),
+        reraise=True,
+        stop=stop_after_attempt(3),
+        wait=wait_random_exponential(max=2 * 60),
+    )
+    def _request(self, url: str, params: dict | None = None) -> Response:
+        response = self.transport.get(url, params)
+        self._check(url, response)
+        return response
+
+    def _request_json(self, action: str, **params) -> dict | None:
+        url = self._build_url(action, **params)
+        return self._parse_json(self._request(url))
 
     def info(self) -> dict:
         today = date.today()
@@ -223,16 +262,121 @@ class FioBank:
         return (self._parse_info(data), self._parse_transactions(data))
 
     def _last_statement_number(self, year: int | None = None) -> tuple[int, int] | None:
-        url = self.base_url + self._actions["last-statement"].format(token=self.token)
+        url = self._build_url("last-statement")
         params = {"year": year} if year is not None else None
-
         response = self._request(url, params=params)
-        year_value, _, number_value = response.text.strip().partition(",")
-        if year_value == "null" or not number_value:
-            return None
-        return (int(year_value), int(number_value))
+        return self._parse_statement_number(response)
 
     def last_statement(self, year: int | None = None) -> Generator[dict]:
         if numbering := self._last_statement_number(year):
             return self.statement(*numbering)
+        raise ValueError("No data available")
+
+
+class AsyncFioBank(FioBankBase):
+    def __init__(
+        self,
+        token: str,
+        *,
+        decimal: bool = False,
+        base_url: str = DEFAULT_BASE_URL,
+        request_timeout: float = 60,
+        transport: AsyncTransport | None = None,
+    ):
+        super().__init__(
+            token,
+            decimal=decimal,
+            base_url=base_url,
+            request_timeout=request_timeout,
+        )
+        self.transport: AsyncTransport = transport or HTTPXAsyncTransport(
+            timeout=request_timeout
+        )
+
+    @retry(
+        retry=retry_if_exception_type(ThrottlingError),
+        reraise=True,
+        stop=stop_after_attempt(3),
+        wait=wait_random_exponential(max=2 * 60),
+    )
+    async def _request(self, url: str, params: dict | None = None) -> Response:
+        # tenacity detects the coroutine and retries it with AsyncRetrying.
+        response = await self.transport.get(url, params)
+        self._check(url, response)
+        return response
+
+    async def _request_json(self, action: str, **params) -> dict | None:
+        url = self._build_url(action, **params)
+        return self._parse_json(await self._request(url))
+
+    async def info(self) -> dict:
+        today = date.today()
+        if data := await self._request_json("periods", from_date=today, to_date=today):
+            return self._parse_info(data)
+        raise ValueError("No data available")
+
+    async def _fetch_period(
+        self, from_date: str | date | datetime, to_date: str | date | datetime
+    ) -> dict:
+        if data := await self._request_json(
+            "periods", from_date=coerce_date(from_date), to_date=coerce_date(to_date)
+        ):
+            return data
+        raise ValueError("No data available")
+
+    async def period(
+        self, from_date: str | date | datetime, to_date: str | date | datetime
+    ) -> Generator[dict]:
+        data = await self._fetch_period(from_date, to_date)
+        return self._parse_transactions(data)
+
+    async def transactions(
+        self, from_date: str | date | datetime, to_date: str | date | datetime
+    ) -> tuple[dict, Generator[dict]]:
+        if data := await self._fetch_period(from_date, to_date):
+            return (self._parse_info(data), self._parse_transactions(data))
+        raise ValueError("No data available")
+
+    async def statement(self, year: int, number: int) -> Generator[dict]:
+        if data := await self._request_json("by-id", year=year, number=number):
+            return self._parse_transactions(data)
+        raise ValueError("No data available")
+
+    async def _fetch_last(
+        self, from_id: str | None = None, from_date: str | date | datetime | None = None
+    ) -> dict:
+        if from_id and from_date:
+            raise ValueError("Only one constraint is allowed.")
+
+        if from_id:
+            await self._request_json("set-last-id", from_id=from_id)
+        elif from_date:
+            await self._request_json("set-last-date", from_date=coerce_date(from_date))
+
+        if data := await self._request_json("last"):
+            return data
+        raise ValueError("No data available")
+
+    async def last(
+        self, from_id: str | None = None, from_date: str | date | datetime | None = None
+    ) -> Generator[dict]:
+        return self._parse_transactions(await self._fetch_last(from_id, from_date))
+
+    async def last_transactions(
+        self, from_id: str | None = None, from_date: str | date | datetime | None = None
+    ) -> tuple[dict, Generator[dict]]:
+        data = await self._fetch_last(from_id, from_date)
+        return (self._parse_info(data), self._parse_transactions(data))
+
+    async def _last_statement_number(
+        self, year: int | None = None
+    ) -> tuple[int, int] | None:
+        url = self._build_url("last-statement")
+        params = {"year": year} if year is not None else None
+        response = await self._request(url, params=params)
+        return self._parse_statement_number(response)
+
+    async def last_statement(self, year: int | None = None) -> Generator[dict]:
+        if numbering := await self._last_statement_number(year):
+            return await self.statement(*numbering)
         raise ValueError("No data available")

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -106,7 +106,13 @@ class FioBankBase:
             raise ThrottlingError()
         if response.status_code >= 400:
             message = f"HTTP {response.status_code} for {url}"
-            body = response.text
+            try:
+                body = response.text
+            except UnicodeDecodeError:
+                # An intermediary (gateway, proxy, WAF) may return a non-UTF-8
+                # error body. Fall back to a lossy decode so the diagnostic
+                # survives instead of masking the HTTPError with a decode crash.
+                body = response.content.decode("utf-8", "replace")
             if body:
                 message = f"{message}. Response body: {body}"
             raise HTTPError(self._sanitize(message), status_code=response.status_code)
@@ -272,6 +278,21 @@ class FioBank(FioBankBase):
             return self.statement(*numbering)
         raise ValueError("No data available")
 
+    def close(self) -> None:
+        """Release the transport (and its default HTTP client, if any).
+
+        A no-op for custom transports that don't expose ``close()``.
+        """
+        close = getattr(self.transport, "close", None)
+        if callable(close):
+            close()
+
+    def __enter__(self) -> FioBank:
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
 
 class AsyncFioBank(FioBankBase):
     def __init__(
@@ -380,3 +401,18 @@ class AsyncFioBank(FioBankBase):
         if numbering := await self._last_statement_number(year):
             return await self.statement(*numbering)
         raise ValueError("No data available")
+
+    async def aclose(self) -> None:
+        """Release the transport (and its default HTTP client, if any).
+
+        A no-op for custom transports that don't expose ``aclose()``.
+        """
+        aclose = getattr(self.transport, "aclose", None)
+        if callable(aclose):
+            await aclose()
+
+    async def __aenter__(self) -> AsyncFioBank:
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.aclose()

--- a/src/fiobank/fiobank.py
+++ b/src/fiobank/fiobank.py
@@ -6,6 +6,7 @@ import warnings
 from collections.abc import Generator
 from datetime import date, datetime
 from decimal import Decimal
+from urllib.parse import urlencode
 
 from tenacity import (
     retry,
@@ -199,8 +200,8 @@ class FioBank(FioBankBase):
         stop=stop_after_attempt(3),
         wait=wait_random_exponential(max=2 * 60),
     )
-    def _request(self, url: str, params: dict | None = None) -> Response:
-        response = self.transport.get(url, params)
+    def _request(self, url: str) -> Response:
+        response = self.transport.get(url)
         self._check(url, response)
         return response
 
@@ -269,9 +270,9 @@ class FioBank(FioBankBase):
 
     def _last_statement_number(self, year: int | None = None) -> tuple[int, int] | None:
         url = self._build_url("last-statement")
-        params = {"year": year} if year is not None else None
-        response = self._request(url, params=params)
-        return self._parse_statement_number(response)
+        if year is not None:
+            url = f"{url}?{urlencode({'year': year})}"
+        return self._parse_statement_number(self._request(url))
 
     def last_statement(self, year: int | None = None) -> Generator[dict]:
         if numbering := self._last_statement_number(year):
@@ -279,13 +280,8 @@ class FioBank(FioBankBase):
         raise ValueError("No data available")
 
     def close(self) -> None:
-        """Release the transport (and its default HTTP client, if any).
-
-        A no-op for custom transports that don't expose ``close()``.
-        """
-        close = getattr(self.transport, "close", None)
-        if callable(close):
-            close()
+        """Close the transport once the client is no longer needed."""
+        self.transport.close()
 
     def __enter__(self) -> FioBank:
         return self
@@ -320,9 +316,8 @@ class AsyncFioBank(FioBankBase):
         stop=stop_after_attempt(3),
         wait=wait_random_exponential(max=2 * 60),
     )
-    async def _request(self, url: str, params: dict | None = None) -> Response:
-        # tenacity detects the coroutine and retries it with AsyncRetrying.
-        response = await self.transport.get(url, params)
+    async def _request(self, url: str) -> Response:
+        response = await self.transport.get(url)
         self._check(url, response)
         return response
 
@@ -393,9 +388,9 @@ class AsyncFioBank(FioBankBase):
         self, year: int | None = None
     ) -> tuple[int, int] | None:
         url = self._build_url("last-statement")
-        params = {"year": year} if year is not None else None
-        response = await self._request(url, params=params)
-        return self._parse_statement_number(response)
+        if year is not None:
+            url = f"{url}?{urlencode({'year': year})}"
+        return self._parse_statement_number(await self._request(url))
 
     async def last_statement(self, year: int | None = None) -> Generator[dict]:
         if numbering := await self._last_statement_number(year):
@@ -403,13 +398,8 @@ class AsyncFioBank(FioBankBase):
         raise ValueError("No data available")
 
     async def aclose(self) -> None:
-        """Release the transport (and its default HTTP client, if any).
-
-        A no-op for custom transports that don't expose ``aclose()``.
-        """
-        aclose = getattr(self.transport, "aclose", None)
-        if callable(aclose):
-            await aclose()
+        """Close the transport once the client is no longer needed."""
+        await self.transport.aclose()
 
     async def __aenter__(self) -> AsyncFioBank:
         return self

--- a/src/fiobank/transports.py
+++ b/src/fiobank/transports.py
@@ -21,72 +21,53 @@ class Response:
 
     @property
     def text(self) -> str:
-        # Fio always returns UTF-8, so decoding here is deterministic and
-        # avoids depending on any HTTP client's encoding guessing.
+        """Decode the body as UTF-8.
+
+        Fio always returns UTF-8, so this is deterministic and avoids
+        depending on any HTTP client's encoding guessing.
+        """
         return self.content.decode("utf-8")
 
 
 class Transport(Protocol):
-    """A synchronous transport does one thing: GET a URL."""
+    """A synchronous transport: GET a URL, then close."""
 
-    def get(self, url: str, params: dict | None = None) -> Response: ...
+    def get(self, url: str) -> Response: ...
+
+    def close(self) -> None: ...
 
 
 class AsyncTransport(Protocol):
-    """An asynchronous transport does one thing: GET a URL."""
+    """An asynchronous transport: GET a URL, then close."""
 
-    async def get(self, url: str, params: dict | None = None) -> Response: ...
+    async def get(self, url: str) -> Response: ...
+
+    async def aclose(self) -> None: ...
 
 
 class HTTPXTransport:
-    """Default synchronous transport, backed by :mod:`httpx`.
-
-    Also usable as a context manager. ``close()`` only closes the underlying
-    client when the transport created it -- an injected client stays under
-    the caller's control.
-    """
+    """Default synchronous transport, backed by :mod:`httpx`."""
 
     def __init__(self, *, timeout: float = 60, client: httpx.Client | None = None):
-        self._owns_client = client is None
         self.client = client or httpx.Client(timeout=timeout)
 
-    def get(self, url: str, params: dict | None = None) -> Response:
-        response = self.client.get(url, params=params)
+    def get(self, url: str) -> Response:
+        response = self.client.get(url)
         return Response(response.status_code, response.content)
 
     def close(self) -> None:
-        if self._owns_client:
-            self.client.close()
-
-    def __enter__(self) -> HTTPXTransport:
-        return self
-
-    def __exit__(self, *exc_info) -> None:
-        self.close()
+        self.client.close()
 
 
 class HTTPXAsyncTransport:
-    """Default asynchronous transport, backed by :mod:`httpx`.
-
-    Also usable as an async context manager. ``aclose()`` only closes the
-    underlying client when the transport created it -- an injected client
-    stays under the caller's control.
-    """
+    """Default asynchronous transport, backed by :mod:`httpx`."""
 
     def __init__(self, *, timeout: float = 60, client: httpx.AsyncClient | None = None):
-        self._owns_client = client is None
         self.client = client or httpx.AsyncClient(timeout=timeout)
 
-    async def get(self, url: str, params: dict | None = None) -> Response:
-        response = await self.client.get(url, params=params)
+    async def get(self, url: str) -> Response:
+        response = await self.client.get(url)
         return Response(response.status_code, response.content)
 
     async def aclose(self) -> None:
-        if self._owns_client:
-            await self.client.aclose()
-
-    async def __aenter__(self) -> HTTPXAsyncTransport:
-        return self
-
-    async def __aexit__(self, *exc_info) -> None:
-        await self.aclose()
+        await self.client.aclose()

--- a/src/fiobank/transports.py
+++ b/src/fiobank/transports.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import httpx
+
+
+@dataclass(frozen=True)
+class Response:
+    """Minimal HTTP response the rest of the library operates on.
+
+    A transport only needs to report the status code and hand back the raw
+    body bytes. Everything else (status interpretation, error messages, token
+    sanitization, JSON decoding) is fiobank's own logic and lives in the
+    client, shared by the sync and async variants.
+    """
+
+    status_code: int
+    content: bytes
+
+    @property
+    def text(self) -> str:
+        # Fio always returns UTF-8, so decoding here is deterministic and
+        # avoids depending on any HTTP client's encoding guessing.
+        return self.content.decode("utf-8")
+
+
+class Transport(Protocol):
+    """A synchronous transport does one thing: GET a URL."""
+
+    def get(self, url: str, params: dict | None = None) -> Response: ...
+
+
+class AsyncTransport(Protocol):
+    """An asynchronous transport does one thing: GET a URL."""
+
+    async def get(self, url: str, params: dict | None = None) -> Response: ...
+
+
+class HTTPXTransport:
+    """Default synchronous transport, backed by :mod:`httpx`."""
+
+    def __init__(self, *, timeout: float = 60, client: httpx.Client | None = None):
+        self.client = client or httpx.Client(timeout=timeout)
+
+    def get(self, url: str, params: dict | None = None) -> Response:
+        response = self.client.get(url, params=params)
+        return Response(response.status_code, response.content)
+
+
+class HTTPXAsyncTransport:
+    """Default asynchronous transport, backed by :mod:`httpx`."""
+
+    def __init__(self, *, timeout: float = 60, client: httpx.AsyncClient | None = None):
+        self.client = client or httpx.AsyncClient(timeout=timeout)
+
+    async def get(self, url: str, params: dict | None = None) -> Response:
+        response = await self.client.get(url, params=params)
+        return Response(response.status_code, response.content)

--- a/src/fiobank/transports.py
+++ b/src/fiobank/transports.py
@@ -39,22 +39,54 @@ class AsyncTransport(Protocol):
 
 
 class HTTPXTransport:
-    """Default synchronous transport, backed by :mod:`httpx`."""
+    """Default synchronous transport, backed by :mod:`httpx`.
+
+    Also usable as a context manager. ``close()`` only closes the underlying
+    client when the transport created it -- an injected client stays under
+    the caller's control.
+    """
 
     def __init__(self, *, timeout: float = 60, client: httpx.Client | None = None):
+        self._owns_client = client is None
         self.client = client or httpx.Client(timeout=timeout)
 
     def get(self, url: str, params: dict | None = None) -> Response:
         response = self.client.get(url, params=params)
         return Response(response.status_code, response.content)
 
+    def close(self) -> None:
+        if self._owns_client:
+            self.client.close()
+
+    def __enter__(self) -> HTTPXTransport:
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
 
 class HTTPXAsyncTransport:
-    """Default asynchronous transport, backed by :mod:`httpx`."""
+    """Default asynchronous transport, backed by :mod:`httpx`.
+
+    Also usable as an async context manager. ``aclose()`` only closes the
+    underlying client when the transport created it -- an injected client
+    stays under the caller's control.
+    """
 
     def __init__(self, *, timeout: float = 60, client: httpx.AsyncClient | None = None):
+        self._owns_client = client is None
         self.client = client or httpx.AsyncClient(timeout=timeout)
 
     async def get(self, url: str, params: dict | None = None) -> Response:
         response = await self.client.get(url, params=params)
         return Response(response.status_code, response.content)
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self.client.aclose()
+
+    async def __aenter__(self) -> HTTPXAsyncTransport:
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.aclose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from fiobank import AsyncFioBank, FioBank, HTTPXAsyncTransport, HTTPXTransport
+
+
+BASE_URL = "https://fioapi.fio.cz/v1/rest/"
+
+Handler = Callable[[httpx.Request], httpx.Response]
+
+
+@pytest.fixture()
+def token() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture()
+def transactions_text() -> str:
+    with open(os.path.dirname(__file__) + "/transactions.json") as f:
+        return f.read()
+
+
+@pytest.fixture()
+def transactions_json() -> dict:
+    with open(os.path.dirname(__file__) + "/transactions.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture()
+def sync_client(token: str):
+    """Build a ``FioBank`` whose transport is driven by an httpx MockTransport.
+
+    The handler receives each ``httpx.Request`` and returns an
+    ``httpx.Response``, so tests stay independent of any real network.
+    """
+
+    def make(handler: Handler, *, decimal: bool = True) -> FioBank:
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        return FioBank(token, decimal=decimal, transport=HTTPXTransport(client=client))
+
+    return make
+
+
+@pytest.fixture()
+def async_client(token: str):
+    """``sync_client`` counterpart for :class:`AsyncFioBank`."""
+
+    def make(handler: Handler, *, decimal: bool = True) -> AsyncFioBank:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        return AsyncFioBank(
+            token, decimal=decimal, transport=HTTPXAsyncTransport(client=client)
+        )
+
+    return make
+
+
+@pytest.fixture()
+def transactions_handler(transactions_text: str) -> Handler:
+    """A handler serving the sample statement for any transactions request and
+    an empty body for the ``set-last-*`` cursor endpoints."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("transactions.json"):
+            return httpx.Response(200, text=transactions_text)
+        if "set-last-" in path:
+            return httpx.Response(200)
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    return handler

--- a/tests/test_async_fiobank.py
+++ b/tests/test_async_fiobank.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from datetime import date
+from decimal import Decimal
+
+import httpx
+import pytest
+import respx
+
+from fiobank import AsyncFioBank, HTTPError
+
+
+BASE_URL = "https://fioapi.fio.cz/v1/rest/"
+
+
+@pytest.fixture()
+def token() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture()
+def transactions_text() -> str:
+    with open(os.path.dirname(__file__) + "/transactions.json") as f:
+        return f.read()
+
+
+@pytest.fixture()
+def client_decimal(token: str, transactions_text: str):
+    with respx.mock(assert_all_called=False) as router:
+        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+        router.get(url__regex=url).mock(
+            return_value=httpx.Response(200, text=transactions_text)
+        )
+
+        url = re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/"
+        router.get(url__regex=url).mock(return_value=httpx.Response(200))
+
+        yield AsyncFioBank(token, decimal=True)
+
+
+async def test_info(client_decimal: AsyncFioBank):
+    info = await client_decimal.info()
+
+    assert info["balance"] == Decimal("2060.52")
+    assert frozenset(info.keys()) == frozenset(
+        [
+            "account_number_full",
+            "account_number",
+            "bank_code",
+            "currency",
+            "iban",
+            "bic",
+            "balance",
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "method, args, kwargs",
+    [
+        ("period", [date(2016, 8, 4), date(2016, 8, 30)], {}),
+        ("period", ["2016-08-04", "2016-08-30"], {}),
+        ("statement", [2016, 308], {}),
+        ("last", [], {"from_id": 308}),
+        ("last", [], {"from_date": date(2016, 8, 4)}),
+        ("last", [], {"from_date": "2016-08-04"}),
+    ],
+)
+async def test_transactions_integration(client_decimal, method, args, kwargs):
+    gen = await getattr(client_decimal, method)(*args, **kwargs)
+
+    count = 0
+    for record in gen:
+        count += 1
+        assert "amount" in record
+
+    assert count > 0
+
+
+async def test_transactions(client_decimal: AsyncFioBank):
+    info, transactions = await client_decimal.transactions("2016-08-04", "2016-08-30")
+    transaction = next(transactions)
+    assert transaction["amount"] == Decimal("-130.0")
+    assert info["balance"] == Decimal("2060.52")
+
+
+async def test_last_transactions(client_decimal: AsyncFioBank):
+    info, transactions = await client_decimal.last_transactions(from_id=308)
+    transaction = next(transactions)
+    assert transaction["amount"] == Decimal("-130.0")
+    assert info["balance"] == Decimal("2060.52")
+
+
+async def test_last_statement(token: str, transactions_text: str):
+    with respx.mock() as router:
+        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
+            return_value=httpx.Response(200, text="2017,12")
+        )
+        by_id = router.get(
+            url__regex=re.escape(BASE_URL)
+            + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
+        ).mock(return_value=httpx.Response(200, text=transactions_text))
+        client = AsyncFioBank(token, decimal=True)
+
+        transactions = list(await client.last_statement())
+
+        assert len(transactions) > 0
+        assert f"by-id/{token}/2017/12/transactions.json" in str(
+            by_id.calls[0].request.url
+        )
+
+
+async def test_last_statement_none(token: str):
+    with respx.mock() as router:
+        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
+            return_value=httpx.Response(200, text="null,null")
+        )
+        client = AsyncFioBank(token, decimal=True)
+
+        with pytest.raises(ValueError, match="No data available"):
+            await client.last_statement(2000)
+
+
+async def test_409_conflict(token: str, transactions_text: str):
+    with respx.mock() as router:
+        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+        router.get(url__regex=url).mock(
+            side_effect=[
+                httpx.Response(409),
+                httpx.Response(200, text=transactions_text),
+            ]
+        )
+        client = AsyncFioBank(token, decimal=True)
+        transactions = await client.last()
+        transaction = next(transactions)
+
+    assert transaction["amount"] == Decimal("-130.0")
+
+
+async def test_http_error_with_token_redaction(token: str):
+    response_body = f"Error occurred with token {token} in the response body"
+
+    with respx.mock() as router:
+        url = re.escape(BASE_URL) + rf"periods/{token}/[^/]+/[^/]+/transactions\.json"
+        router.get(url__regex=url).mock(
+            return_value=httpx.Response(400, text=response_body)
+        )
+        client = AsyncFioBank(token, decimal=True)
+
+        with pytest.raises(HTTPError) as exc_info:
+            await client.period("2025-01-01", "2025-02-01")
+
+        assert exc_info.value.status_code == 400
+        error_msg = str(exc_info.value)
+        assert token not in error_msg
+        assert "***TOKEN***" in error_msg
+        assert "Error occurred with token ***TOKEN*** in the response body" in error_msg
+
+
+async def test_last_conflicting_params():
+    client = AsyncFioBank("...", decimal=True)
+    with pytest.raises(ValueError):
+        await client.last(from_id=308, from_date=date(2016, 8, 30))

--- a/tests/test_async_fiobank.py
+++ b/tests/test_async_fiobank.py
@@ -1,44 +1,17 @@
 from __future__ import annotations
 
-import os
-import re
-import uuid
 from datetime import date
 from decimal import Decimal
 
 import httpx
 import pytest
-import respx
 
 from fiobank import AsyncFioBank, HTTPError
 
 
-BASE_URL = "https://fioapi.fio.cz/v1/rest/"
-
-
 @pytest.fixture()
-def token() -> str:
-    return str(uuid.uuid4())
-
-
-@pytest.fixture()
-def transactions_text() -> str:
-    with open(os.path.dirname(__file__) + "/transactions.json") as f:
-        return f.read()
-
-
-@pytest.fixture()
-def client_decimal(token: str, transactions_text: str):
-    with respx.mock(assert_all_called=False) as router:
-        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
-        router.get(url__regex=url).mock(
-            return_value=httpx.Response(200, text=transactions_text)
-        )
-
-        url = re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/"
-        router.get(url__regex=url).mock(return_value=httpx.Response(200))
-
-        yield AsyncFioBank(token, decimal=True)
+def client_decimal(async_client, transactions_handler) -> AsyncFioBank:
+    return async_client(transactions_handler, decimal=True)
 
 
 async def test_info(client_decimal: AsyncFioBank):
@@ -94,70 +67,51 @@ async def test_last_transactions(client_decimal: AsyncFioBank):
     assert info["balance"] == Decimal("2060.52")
 
 
-async def test_last_statement(token: str, transactions_text: str):
-    with respx.mock() as router:
-        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
-            return_value=httpx.Response(200, text="2017,12")
-        )
-        by_id = router.get(
-            url__regex=re.escape(BASE_URL)
-            + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
-        ).mock(return_value=httpx.Response(200, text=transactions_text))
-        client = AsyncFioBank(token, decimal=True)
+async def test_last_statement(async_client, token: str, transactions_text: str):
+    requests: list[httpx.Request] = []
 
-        transactions = list(await client.last_statement())
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("statement"):
+            return httpx.Response(200, text="2017,12")
+        return httpx.Response(200, text=transactions_text)
 
-        assert len(transactions) > 0
-        assert f"by-id/{token}/2017/12/transactions.json" in str(
-            by_id.calls[0].request.url
-        )
+    client = async_client(handler)
+
+    transactions = list(await client.last_statement())
+
+    assert len(transactions) > 0
+    assert f"by-id/{token}/2017/12/transactions.json" in str(requests[-1].url)
 
 
-async def test_last_statement_none(token: str):
-    with respx.mock() as router:
-        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
-            return_value=httpx.Response(200, text="null,null")
-        )
-        client = AsyncFioBank(token, decimal=True)
+async def test_last_statement_none(async_client):
+    client = async_client(lambda request: httpx.Response(200, text="null,null"))
 
-        with pytest.raises(ValueError, match="No data available"):
-            await client.last_statement(2000)
+    with pytest.raises(ValueError, match="No data available"):
+        await client.last_statement(2000)
 
 
-async def test_409_conflict(token: str, transactions_text: str):
-    with respx.mock() as router:
-        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
-        router.get(url__regex=url).mock(
-            side_effect=[
-                httpx.Response(409),
-                httpx.Response(200, text=transactions_text),
-            ]
-        )
-        client = AsyncFioBank(token, decimal=True)
-        transactions = await client.last()
-        transaction = next(transactions)
+async def test_409_conflict(async_client, transactions_text: str):
+    responses = [httpx.Response(409), httpx.Response(200, text=transactions_text)]
+    client = async_client(lambda request: responses.pop(0))
+
+    transaction = next(await client.last())
 
     assert transaction["amount"] == Decimal("-130.0")
 
 
-async def test_http_error_with_token_redaction(token: str):
+async def test_http_error_with_token_redaction(async_client, token: str):
     response_body = f"Error occurred with token {token} in the response body"
+    client = async_client(lambda request: httpx.Response(400, text=response_body))
 
-    with respx.mock() as router:
-        url = re.escape(BASE_URL) + rf"periods/{token}/[^/]+/[^/]+/transactions\.json"
-        router.get(url__regex=url).mock(
-            return_value=httpx.Response(400, text=response_body)
-        )
-        client = AsyncFioBank(token, decimal=True)
+    with pytest.raises(HTTPError) as exc_info:
+        await client.period("2025-01-01", "2025-02-01")
 
-        with pytest.raises(HTTPError) as exc_info:
-            await client.period("2025-01-01", "2025-02-01")
-
-        assert exc_info.value.status_code == 400
-        error_msg = str(exc_info.value)
-        assert token not in error_msg
-        assert "***TOKEN***" in error_msg
-        assert "Error occurred with token ***TOKEN*** in the response body" in error_msg
+    assert exc_info.value.status_code == 400
+    error_msg = str(exc_info.value)
+    assert token not in error_msg
+    assert "***TOKEN***" in error_msg
+    assert "Error occurred with token ***TOKEN*** in the response body" in error_msg
 
 
 async def test_last_conflicting_params():

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import json
-import os
 import re
-import uuid
 from datetime import date
 from decimal import Decimal
 from unittest import mock
 
 import httpx
 import pytest
-import respx
 
 from fiobank import FioBank, HTTPError
 from fiobank.models import Transaction
@@ -20,48 +16,13 @@ BASE_URL = "https://fioapi.fio.cz/v1/rest/"
 
 
 @pytest.fixture()
-def token() -> str:
-    return str(uuid.uuid4())
+def client_float(sync_client, transactions_handler) -> FioBank:
+    return sync_client(transactions_handler, decimal=False)
 
 
 @pytest.fixture()
-def transactions_text() -> str:
-    with open(os.path.dirname(__file__) + "/transactions.json") as f:
-        return f.read()
-
-
-@pytest.fixture()
-def transactions_json() -> dict:
-    with open(os.path.dirname(__file__) + "/transactions.json") as f:
-        return json.load(f)
-
-
-@pytest.fixture()
-def client_float(token: str, transactions_text: str):
-    with respx.mock(assert_all_called=False) as router:
-        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
-        router.get(url__regex=url).mock(
-            return_value=httpx.Response(200, text=transactions_text)
-        )
-
-        url = re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/"
-        router.get(url__regex=url).mock(return_value=httpx.Response(200))
-
-        yield FioBank(token)
-
-
-@pytest.fixture()
-def client_decimal(token: str, transactions_text: str):
-    with respx.mock(assert_all_called=False) as router:
-        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
-        router.get(url__regex=url).mock(
-            return_value=httpx.Response(200, text=transactions_text)
-        )
-
-        url = re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/"
-        router.get(url__regex=url).mock(return_value=httpx.Response(200))
-
-        yield FioBank(token, decimal=True)
+def client_decimal(sync_client, transactions_handler) -> FioBank:
+    return sync_client(transactions_handler, decimal=True)
 
 
 def test_client_decimal(client_decimal: FioBank):
@@ -485,67 +446,49 @@ def test_transactions_parse_no_account_number_full(transactions_json):
     assert sdk_transaction["account_number_full"] is None
 
 
-def test_last_statement(token: str, transactions_text: str):
-    with respx.mock() as router:
-        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
-            return_value=httpx.Response(200, text="2017,12")
-        )
-        by_id = router.get(
-            url__regex=re.escape(BASE_URL)
-            + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
-        ).mock(return_value=httpx.Response(200, text=transactions_text))
-        client = FioBank(token, decimal=True)
+def _statement_handler(number_text: str, transactions_text: str, requests: list):
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("statement"):
+            return httpx.Response(200, text=number_text)
+        return httpx.Response(200, text=transactions_text)
 
-        transactions = list(client.last_statement())
-
-        assert len(transactions) > 0
-        # the last statement (2017/12) is fetched via the by-id endpoint
-        assert f"by-id/{token}/2017/12/transactions.json" in str(
-            by_id.calls[0].request.url
-        )
+    return handler
 
 
-def test_last_statement_year(token: str, transactions_text: str):
-    with respx.mock() as router:
-        last_statement = router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
-            return_value=httpx.Response(200, text="2016,3")
-        )
-        by_id = router.get(
-            url__regex=re.escape(BASE_URL)
-            + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
-        ).mock(return_value=httpx.Response(200, text=transactions_text))
-        client = FioBank(token, decimal=True)
+def test_last_statement(sync_client, token: str, transactions_text: str):
+    requests: list[httpx.Request] = []
+    client = sync_client(_statement_handler("2017,12", transactions_text, requests))
 
-        list(client.last_statement(2016))
+    transactions = list(client.last_statement())
 
-        assert dict(last_statement.calls[0].request.url.params) == {"year": "2016"}
-        assert f"by-id/{token}/2016/3/transactions.json" in str(
-            by_id.calls[0].request.url
-        )
+    assert len(transactions) > 0
+    # the last statement (2017/12) is fetched via the by-id endpoint
+    assert f"by-id/{token}/2017/12/transactions.json" in str(requests[-1].url)
 
 
-def test_last_statement_none(token: str):
-    with respx.mock() as router:
-        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
-            return_value=httpx.Response(200, text="null,null")
-        )
-        client = FioBank(token, decimal=True)
+def test_last_statement_year(sync_client, token: str, transactions_text: str):
+    requests: list[httpx.Request] = []
+    client = sync_client(_statement_handler("2016,3", transactions_text, requests))
 
-        with pytest.raises(ValueError, match="No data available"):
-            client.last_statement(2000)
+    list(client.last_statement(2016))
+
+    assert dict(requests[0].url.params) == {"year": "2016"}
+    assert f"by-id/{token}/2016/3/transactions.json" in str(requests[-1].url)
 
 
-def test_409_conflict(token: str, transactions_text: str):
-    with respx.mock() as router:
-        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
-        router.get(url__regex=url).mock(
-            side_effect=[
-                httpx.Response(409),
-                httpx.Response(200, text=transactions_text),
-            ]
-        )
-        client = FioBank(token, decimal=True)
-        transaction = next(client.last())
+def test_last_statement_none(sync_client):
+    client = sync_client(lambda request: httpx.Response(200, text="null,null"))
+
+    with pytest.raises(ValueError, match="No data available"):
+        client.last_statement(2000)
+
+
+def test_409_conflict(sync_client, transactions_text: str):
+    responses = [httpx.Response(409), httpx.Response(200, text=transactions_text)]
+    client = sync_client(lambda request: responses.pop(0))
+
+    transaction = next(client.last())
 
     assert transaction["amount"] == Decimal("-130.0")
 
@@ -557,39 +500,30 @@ def test_removed_schema_attributes(attr):
         getattr(client, attr)
 
 
-def test_http_error_with_token_redaction(token: str):
+def test_http_error_with_token_redaction(sync_client, token: str):
     response_body = f"Error occurred with token {token} in the response body"
+    client = sync_client(lambda request: httpx.Response(400, text=response_body))
 
-    with respx.mock() as router:
-        url = re.escape(BASE_URL) + rf"periods/{token}/[^/]+/[^/]+/transactions\.json"
-        router.get(url__regex=url).mock(
-            return_value=httpx.Response(400, text=response_body)
-        )
-        client = FioBank(token, decimal=True)
+    with pytest.raises(HTTPError) as exc_info:
+        list(client.period("2025-01-01", "2025-02-01"))
 
-        with pytest.raises(HTTPError) as exc_info:
-            list(client.period("2025-01-01", "2025-02-01"))
-
-        assert exc_info.value.status_code == 400
-        error_msg = str(exc_info.value)
-        # Token should be redacted from both URL and response body
-        assert token not in error_msg
-        assert "***TOKEN***" in error_msg
-        assert "Error occurred with token ***TOKEN*** in the response body" in error_msg
+    assert exc_info.value.status_code == 400
+    error_msg = str(exc_info.value)
+    # Token should be redacted from both URL and response body
+    assert token not in error_msg
+    assert "***TOKEN***" in error_msg
+    assert "Error occurred with token ***TOKEN*** in the response body" in error_msg
 
 
-def test_http_error_with_non_utf8_body(token: str):
+def test_http_error_with_non_utf8_body(sync_client):
     # An intermediary (proxy/WAF) may return a non-UTF-8 error body; that must
     # still surface as a clean HTTPError, not a UnicodeDecodeError crash.
-    with respx.mock() as router:
-        url = re.escape(BASE_URL) + rf"periods/{token}/[^/]+/[^/]+/transactions\.json"
-        router.get(url__regex=url).mock(
-            return_value=httpx.Response(502, content=b"\xff\xfe bad gateway")
-        )
-        client = FioBank(token, decimal=True)
+    client = sync_client(
+        lambda request: httpx.Response(502, content=b"\xff\xfe bad gateway")
+    )
 
-        with pytest.raises(HTTPError) as exc_info:
-            list(client.period("2025-01-01", "2025-02-01"))
+    with pytest.raises(HTTPError) as exc_info:
+        list(client.period("2025-01-01", "2025-02-01"))
 
-        assert exc_info.value.status_code == 502
-        assert "bad gateway" in str(exc_info.value)
+    assert exc_info.value.status_code == 502
+    assert "bad gateway" in str(exc_info.value)

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -576,3 +576,20 @@ def test_http_error_with_token_redaction(token: str):
         assert token not in error_msg
         assert "***TOKEN***" in error_msg
         assert "Error occurred with token ***TOKEN*** in the response body" in error_msg
+
+
+def test_http_error_with_non_utf8_body(token: str):
+    # An intermediary (proxy/WAF) may return a non-UTF-8 error body; that must
+    # still surface as a clean HTTPError, not a UnicodeDecodeError crash.
+    with respx.mock() as router:
+        url = re.escape(BASE_URL) + rf"periods/{token}/[^/]+/[^/]+/transactions\.json"
+        router.get(url__regex=url).mock(
+            return_value=httpx.Response(502, content=b"\xff\xfe bad gateway")
+        )
+        client = FioBank(token, decimal=True)
+
+        with pytest.raises(HTTPError) as exc_info:
+            list(client.period("2025-01-01", "2025-02-01"))
+
+        assert exc_info.value.status_code == 502
+        assert "bad gateway" in str(exc_info.value)

--- a/tests/test_fiobank.py
+++ b/tests/test_fiobank.py
@@ -8,12 +8,11 @@ from datetime import date
 from decimal import Decimal
 from unittest import mock
 
+import httpx
 import pytest
-import requests
-import responses
-from responses.registries import OrderedRegistry
+import respx
 
-from fiobank import FioBank
+from fiobank import FioBank, HTTPError
 from fiobank.models import Transaction
 
 
@@ -39,28 +38,28 @@ def transactions_json() -> dict:
 
 @pytest.fixture()
 def client_float(token: str, transactions_text: str):
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as resps:
-        url = re.compile(
-            re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+    with respx.mock(assert_all_called=False) as router:
+        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+        router.get(url__regex=url).mock(
+            return_value=httpx.Response(200, text=transactions_text)
         )
-        resps.add(responses.GET, url, body=transactions_text)
 
-        url = re.compile(re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/")
-        resps.add(responses.GET, url)
+        url = re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/"
+        router.get(url__regex=url).mock(return_value=httpx.Response(200))
 
         yield FioBank(token)
 
 
 @pytest.fixture()
 def client_decimal(token: str, transactions_text: str):
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as resps:
-        url = re.compile(
-            re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+    with respx.mock(assert_all_called=False) as router:
+        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+        router.get(url__regex=url).mock(
+            return_value=httpx.Response(200, text=transactions_text)
         )
-        resps.add(responses.GET, url, body=transactions_text)
 
-        url = re.compile(re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/")
-        resps.add(responses.GET, url)
+        url = re.escape(BASE_URL) + rf"set-last-\w+/{token}/[^/]+/"
+        router.get(url__regex=url).mock(return_value=httpx.Response(200))
 
         yield FioBank(token, decimal=True)
 
@@ -296,9 +295,9 @@ def test_transaction_schema_is_complete():
     # runtimes (e.g. AI agent coding environment). Skip cleanly there
     # rather than failing. CI has network access and runs the assertion.
     try:
-        response = requests.get("https://www.fio.cz/xsd/IBSchema.xsd", timeout=10)
+        response = httpx.get("https://www.fio.cz/xsd/IBSchema.xsd", timeout=10)
         response.raise_for_status()
-    except requests.RequestException as e:
+    except httpx.HTTPError as e:
         pytest.skip(f"www.fio.cz is not reachable from this runtime: {e}")
 
     columns_in_xsd = set()
@@ -487,56 +486,48 @@ def test_transactions_parse_no_account_number_full(transactions_json):
 
 
 def test_last_statement(token: str, transactions_text: str):
-    with responses.RequestsMock() as resps:
-        resps.add(
-            responses.GET,
-            BASE_URL + f"lastStatement/{token}/statement",
-            body="2017,12",
+    with respx.mock() as router:
+        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
+            return_value=httpx.Response(200, text="2017,12")
         )
-        resps.add(
-            responses.GET,
-            re.compile(
-                re.escape(BASE_URL) + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
-            ),
-            body=transactions_text,
-        )
+        by_id = router.get(
+            url__regex=re.escape(BASE_URL)
+            + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
+        ).mock(return_value=httpx.Response(200, text=transactions_text))
         client = FioBank(token, decimal=True)
 
         transactions = list(client.last_statement())
 
         assert len(transactions) > 0
         # the last statement (2017/12) is fetched via the by-id endpoint
-        assert f"by-id/{token}/2017/12/transactions.json" in resps.calls[1].request.url
+        assert f"by-id/{token}/2017/12/transactions.json" in str(
+            by_id.calls[0].request.url
+        )
 
 
 def test_last_statement_year(token: str, transactions_text: str):
-    with responses.RequestsMock() as resps:
-        resps.add(
-            responses.GET,
-            BASE_URL + f"lastStatement/{token}/statement",
-            body="2016,3",
+    with respx.mock() as router:
+        last_statement = router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
+            return_value=httpx.Response(200, text="2016,3")
         )
-        resps.add(
-            responses.GET,
-            re.compile(
-                re.escape(BASE_URL) + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
-            ),
-            body=transactions_text,
-        )
+        by_id = router.get(
+            url__regex=re.escape(BASE_URL)
+            + rf"by-id/{token}/[^/]+/[^/]+/transactions\.json"
+        ).mock(return_value=httpx.Response(200, text=transactions_text))
         client = FioBank(token, decimal=True)
 
         list(client.last_statement(2016))
 
-        assert resps.calls[0].request.params == {"year": "2016"}
-        assert f"by-id/{token}/2016/3/transactions.json" in resps.calls[1].request.url
+        assert dict(last_statement.calls[0].request.url.params) == {"year": "2016"}
+        assert f"by-id/{token}/2016/3/transactions.json" in str(
+            by_id.calls[0].request.url
+        )
 
 
 def test_last_statement_none(token: str):
-    with responses.RequestsMock() as resps:
-        resps.add(
-            responses.GET,
-            BASE_URL + f"lastStatement/{token}/statement",
-            body="null,null",
+    with respx.mock() as router:
+        router.get(BASE_URL + f"lastStatement/{token}/statement").mock(
+            return_value=httpx.Response(200, text="null,null")
         )
         client = FioBank(token, decimal=True)
 
@@ -545,12 +536,14 @@ def test_last_statement_none(token: str):
 
 
 def test_409_conflict(token: str, transactions_text: str):
-    with responses.RequestsMock(registry=OrderedRegistry) as resps:
-        url = re.compile(
-            re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+    with respx.mock() as router:
+        url = re.escape(BASE_URL) + rf"[^/]+/{token}/([^/]+/)*transactions\.json"
+        router.get(url__regex=url).mock(
+            side_effect=[
+                httpx.Response(409),
+                httpx.Response(200, text=transactions_text),
+            ]
         )
-        resps.add(responses.GET, url, status=409)
-        resps.add(responses.GET, url, body=transactions_text)
         client = FioBank(token, decimal=True)
         transaction = next(client.last())
 
@@ -567,16 +560,17 @@ def test_removed_schema_attributes(attr):
 def test_http_error_with_token_redaction(token: str):
     response_body = f"Error occurred with token {token} in the response body"
 
-    with responses.RequestsMock() as resps:
-        url = re.compile(
-            re.escape(BASE_URL) + rf"periods/{token}/[^/]+/[^/]+/transactions\.json"
+    with respx.mock() as router:
+        url = re.escape(BASE_URL) + rf"periods/{token}/[^/]+/[^/]+/transactions\.json"
+        router.get(url__regex=url).mock(
+            return_value=httpx.Response(400, text=response_body)
         )
-        resps.add(responses.GET, url, status=400, body=response_body)
         client = FioBank(token, decimal=True)
 
-        with pytest.raises(requests.HTTPError) as exc_info:
+        with pytest.raises(HTTPError) as exc_info:
             list(client.period("2025-01-01", "2025-02-01"))
 
+        assert exc_info.value.status_code == 400
         error_msg = str(exc_info.value)
         # Token should be redacted from both URL and response body
         assert token not in error_msg

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -35,8 +35,8 @@ def test_httpx_transport_returns_response():
         router.get("https://example.test/").mock(
             return_value=httpx.Response(201, text="hello")
         )
-        transport = HTTPXTransport()
-        response = transport.get("https://example.test/")
+        with HTTPXTransport() as transport:
+            response = transport.get("https://example.test/")
 
     assert isinstance(response, Response)
     assert response.status_code == 201
@@ -48,12 +48,57 @@ async def test_httpx_async_transport_returns_response():
         router.get("https://example.test/").mock(
             return_value=httpx.Response(202, text="hello")
         )
-        transport = HTTPXAsyncTransport()
-        response = await transport.get("https://example.test/")
+        async with HTTPXAsyncTransport() as transport:
+            response = await transport.get("https://example.test/")
 
     assert isinstance(response, Response)
     assert response.status_code == 202
     assert response.text == "hello"
+
+
+def test_httpx_transport_close_owns_default_client():
+    transport = HTTPXTransport()
+    transport.close()
+    assert transport.client.is_closed
+
+
+def test_httpx_transport_close_leaves_injected_client_open():
+    client = httpx.Client()
+    transport = HTTPXTransport(client=client)
+    transport.close()
+    assert not client.is_closed
+    client.close()
+
+
+async def test_httpx_async_transport_aclose_owns_default_client():
+    transport = HTTPXAsyncTransport()
+    await transport.aclose()
+    assert transport.client.is_closed
+
+
+async def test_httpx_async_transport_aclose_leaves_injected_client_open():
+    client = httpx.AsyncClient()
+    transport = HTTPXAsyncTransport(client=client)
+    await transport.aclose()
+    assert not client.is_closed
+    await client.aclose()
+
+
+def test_fiobank_context_manager_closes_default_transport():
+    with FioBank("token", decimal=True) as client:
+        transport = client.transport
+    assert transport.client.is_closed
+
+
+async def test_async_fiobank_context_manager_closes_default_transport():
+    async with AsyncFioBank("token", decimal=True) as client:
+        transport = client.transport
+    assert transport.client.is_closed
+
+
+def test_fiobank_close_is_noop_for_transport_without_close():
+    client = FioBank("token", decimal=True, transport=FakeTransport("{}"))
+    client.close()  # must not raise even though FakeTransport has no close()
 
 
 class FakeTransport:

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+
+import httpx
+import pytest
+import respx
+
+from fiobank import (
+    AsyncFioBank,
+    FioBank,
+    HTTPXAsyncTransport,
+    HTTPXTransport,
+    Response,
+)
+
+
+BASE_URL = "https://fioapi.fio.cz/v1/rest/"
+
+
+@pytest.fixture()
+def transactions_text() -> str:
+    with open(os.path.dirname(__file__) + "/transactions.json") as f:
+        return f.read()
+
+
+def test_response_text_decodes_utf8():
+    response = Response(200, "Vilém Fusek".encode())
+    assert response.text == "Vilém Fusek"
+
+
+def test_httpx_transport_returns_response():
+    with respx.mock() as router:
+        router.get("https://example.test/").mock(
+            return_value=httpx.Response(201, text="hello")
+        )
+        transport = HTTPXTransport()
+        response = transport.get("https://example.test/")
+
+    assert isinstance(response, Response)
+    assert response.status_code == 201
+    assert response.text == "hello"
+
+
+async def test_httpx_async_transport_returns_response():
+    with respx.mock() as router:
+        router.get("https://example.test/").mock(
+            return_value=httpx.Response(202, text="hello")
+        )
+        transport = HTTPXAsyncTransport()
+        response = await transport.get("https://example.test/")
+
+    assert isinstance(response, Response)
+    assert response.status_code == 202
+    assert response.text == "hello"
+
+
+class FakeTransport:
+    """A custom transport implementing the ``Transport`` protocol without
+    touching the network -- exactly the pluggability issue #45 is about."""
+
+    def __init__(self, body: str):
+        self.body = body
+        self.requests: list[tuple[str, dict | None]] = []
+
+    def get(self, url: str, params: dict | None = None) -> Response:
+        self.requests.append((url, params))
+        return Response(200, self.body.encode("utf-8"))
+
+
+def test_custom_transport_is_used(transactions_text: str):
+    transport = FakeTransport(transactions_text)
+    client = FioBank("token", decimal=True, transport=transport)
+
+    transaction = next(client.last())
+
+    assert transaction["amount"] == Decimal("-130.0")
+    assert transport.requests  # the custom transport did the work
+    assert all("token" in url for url, _ in transport.requests)
+
+
+class FakeAsyncTransport:
+    def __init__(self, body: str):
+        self.body = body
+
+    async def get(self, url: str, params: dict | None = None) -> Response:
+        return Response(200, self.body.encode("utf-8"))
+
+
+async def test_custom_async_transport_is_used(transactions_text: str):
+    transport = FakeAsyncTransport(transactions_text)
+    client = AsyncFioBank("token", decimal=True, transport=transport)
+
+    transactions = await client.last()
+
+    assert next(transactions)["amount"] == Decimal("-130.0")

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import os
 from decimal import Decimal
 
 import httpx
-import pytest
-import respx
 
 from fiobank import (
     AsyncFioBank,
@@ -16,27 +13,19 @@ from fiobank import (
 )
 
 
-BASE_URL = "https://fioapi.fio.cz/v1/rest/"
-
-
-@pytest.fixture()
-def transactions_text() -> str:
-    with open(os.path.dirname(__file__) + "/transactions.json") as f:
-        return f.read()
-
-
 def test_response_text_decodes_utf8():
     response = Response(200, "Vilém Fusek".encode())
     assert response.text == "Vilém Fusek"
 
 
 def test_httpx_transport_returns_response():
-    with respx.mock() as router:
-        router.get("https://example.test/").mock(
-            return_value=httpx.Response(201, text="hello")
-        )
-        with HTTPXTransport() as transport:
-            response = transport.get("https://example.test/")
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda request: httpx.Response(201, text="hello"))
+    )
+    transport = HTTPXTransport(client=client)
+
+    response = transport.get("https://example.test/")
+    transport.close()
 
     assert isinstance(response, Response)
     assert response.status_code == 201
@@ -44,61 +33,41 @@ def test_httpx_transport_returns_response():
 
 
 async def test_httpx_async_transport_returns_response():
-    with respx.mock() as router:
-        router.get("https://example.test/").mock(
-            return_value=httpx.Response(202, text="hello")
-        )
-        async with HTTPXAsyncTransport() as transport:
-            response = await transport.get("https://example.test/")
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(202, text="hello"))
+    )
+    transport = HTTPXAsyncTransport(client=client)
+
+    response = await transport.get("https://example.test/")
+    await transport.aclose()
 
     assert isinstance(response, Response)
     assert response.status_code == 202
     assert response.text == "hello"
 
 
-def test_httpx_transport_close_owns_default_client():
+def test_httpx_transport_close_closes_client():
     transport = HTTPXTransport()
     transport.close()
     assert transport.client.is_closed
 
 
-def test_httpx_transport_close_leaves_injected_client_open():
-    client = httpx.Client()
-    transport = HTTPXTransport(client=client)
-    transport.close()
-    assert not client.is_closed
-    client.close()
-
-
-async def test_httpx_async_transport_aclose_owns_default_client():
+async def test_httpx_async_transport_aclose_closes_client():
     transport = HTTPXAsyncTransport()
     await transport.aclose()
     assert transport.client.is_closed
 
 
-async def test_httpx_async_transport_aclose_leaves_injected_client_open():
-    client = httpx.AsyncClient()
-    transport = HTTPXAsyncTransport(client=client)
-    await transport.aclose()
-    assert not client.is_closed
-    await client.aclose()
-
-
-def test_fiobank_context_manager_closes_default_transport():
+def test_fiobank_context_manager_closes_transport():
     with FioBank("token", decimal=True) as client:
         transport = client.transport
     assert transport.client.is_closed
 
 
-async def test_async_fiobank_context_manager_closes_default_transport():
+async def test_async_fiobank_context_manager_closes_transport():
     async with AsyncFioBank("token", decimal=True) as client:
         transport = client.transport
     assert transport.client.is_closed
-
-
-def test_fiobank_close_is_noop_for_transport_without_close():
-    client = FioBank("token", decimal=True, transport=FakeTransport("{}"))
-    client.close()  # must not raise even though FakeTransport has no close()
 
 
 class FakeTransport:
@@ -107,36 +76,45 @@ class FakeTransport:
 
     def __init__(self, body: str):
         self.body = body
-        self.requests: list[tuple[str, dict | None]] = []
+        self.requests: list[str] = []
+        self.closed = False
 
-    def get(self, url: str, params: dict | None = None) -> Response:
-        self.requests.append((url, params))
-        return Response(200, self.body.encode("utf-8"))
+    def get(self, url: str) -> Response:
+        self.requests.append(url)
+        return Response(200, self.body.encode())
+
+    def close(self) -> None:
+        self.closed = True
 
 
-def test_custom_transport_is_used(transactions_text: str):
+def test_custom_transport_is_used_and_closed(transactions_text: str):
     transport = FakeTransport(transactions_text)
-    client = FioBank("token", decimal=True, transport=transport)
 
-    transaction = next(client.last())
+    with FioBank("token", decimal=True, transport=transport) as client:
+        transaction = next(client.last())
 
     assert transaction["amount"] == Decimal("-130.0")
-    assert transport.requests  # the custom transport did the work
-    assert all("token" in url for url, _ in transport.requests)
+    assert all("token" in url for url in transport.requests)
+    assert transport.closed
 
 
 class FakeAsyncTransport:
     def __init__(self, body: str):
         self.body = body
+        self.closed = False
 
-    async def get(self, url: str, params: dict | None = None) -> Response:
-        return Response(200, self.body.encode("utf-8"))
+    async def get(self, url: str) -> Response:
+        return Response(200, self.body.encode())
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
-async def test_custom_async_transport_is_used(transactions_text: str):
+async def test_custom_async_transport_is_used_and_closed(transactions_text: str):
     transport = FakeAsyncTransport(transactions_text)
-    client = AsyncFioBank("token", decimal=True, transport=transport)
 
-    transactions = await client.last()
+    async with AsyncFioBank("token", decimal=True, transport=transport) as client:
+        transactions = await client.last()
 
     assert next(transactions)["amount"] == Decimal("-130.0")
+    assert transport.closed

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,6 @@ dev = [
     { name = "pytest-asyncio", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
     { name = "pytest-ruff" },
-    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -366,7 +365,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-ruff", specifier = ">=0.4.1" },
-    { name = "respx", specifier = ">=0.21.1" },
     { name = "ruff", specifier = ">=0.8.4" },
 ]
 
@@ -726,18 +724,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/5a/bee55130757fb4a14e0ac5d2c6558323275b5dccfa2f5353f3893299ff7d/pytest_ruff-0.5.tar.gz", hash = "sha256:f611c780fc2b9b8d7041fa0e7589f0a9f352b288d0cfc330881101b35d382063", size = 3854, upload-time = "2025-06-19T07:26:24.607Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/ca/abfce6de0bb0f017ed05ef9f2330596235cc5a3341b4d8d40895682b3814/pytest_ruff-0.5-py3-none-any.whl", hash = "sha256:d9db170d86fb167008e6702b4d79e2cccd8287f069c3a57f9261831cebdc4a31", size = 4680, upload-time = "2025-06-19T07:26:23.897Z" },
-]
-
-[[package]]
-name = "respx"
-version = "0.23.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 4
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -16,117 +16,55 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/af/1f9d7f7faafe2ddfb6f72a2e07a548a629c61ad510fe60f9630309908fef/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8", size = 148814, upload-time = "2025-10-14T04:40:13.135Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3d/f2e3ac2bbc056ca0c204298ea4e3d9db9b4afe437812638759db2c976b5f/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad", size = 144467, upload-time = "2025-10-14T04:40:14.728Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/85/1bf997003815e60d57de7bd972c57dc6950446a3e4ccac43bc3070721856/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8", size = 162280, upload-time = "2025-10-14T04:40:16.14Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/8e/6aa1952f56b192f54921c436b87f2aaf7c7a7c3d0d1a765547d64fd83c13/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d", size = 159454, upload-time = "2025-10-14T04:40:17.567Z" },
-    { url = "https://files.pythonhosted.org/packages/36/3b/60cbd1f8e93aa25d1c669c649b7a655b0b5fb4c571858910ea9332678558/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313", size = 153609, upload-time = "2025-10-14T04:40:19.08Z" },
-    { url = "https://files.pythonhosted.org/packages/64/91/6a13396948b8fd3c4b4fd5bc74d045f5637d78c9675585e8e9fbe5636554/charset_normalizer-3.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e", size = 151849, upload-time = "2025-10-14T04:40:20.607Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7a/59482e28b9981d105691e968c544cc0df3b7d6133152fb3dcdc8f135da7a/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93", size = 151586, upload-time = "2025-10-14T04:40:21.719Z" },
-    { url = "https://files.pythonhosted.org/packages/92/59/f64ef6a1c4bdd2baf892b04cd78792ed8684fbc48d4c2afe467d96b4df57/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0", size = 145290, upload-time = "2025-10-14T04:40:23.069Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/63/3bf9f279ddfa641ffa1962b0db6a57a9c294361cc2f5fcac997049a00e9c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84", size = 163663, upload-time = "2025-10-14T04:40:24.17Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/09/c9e38fc8fa9e0849b172b581fd9803bdf6e694041127933934184e19f8c3/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e", size = 151964, upload-time = "2025-10-14T04:40:25.368Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/d1/d28b747e512d0da79d8b6a1ac18b7ab2ecfd81b2944c4c710e166d8dd09c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db", size = 161064, upload-time = "2025-10-14T04:40:26.806Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/9a/31d62b611d901c3b9e5500c36aab0ff5eb442043fb3a1c254200d3d397d9/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6", size = 155015, upload-time = "2025-10-14T04:40:28.284Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f3/107e008fa2bff0c8b9319584174418e5e5285fef32f79d8ee6a430d0039c/charset_normalizer-3.4.4-cp310-cp310-win32.whl", hash = "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f", size = 99792, upload-time = "2025-10-14T04:40:29.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/66/e396e8a408843337d7315bab30dbf106c38966f1819f123257f5520f8a96/charset_normalizer-3.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d", size = 107198, upload-time = "2025-10-14T04:40:30.644Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/58/01b4f815bf0312704c267f2ccb6e5d42bcc7752340cd487bc9f8c3710597/charset_normalizer-3.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69", size = 100262, upload-time = "2025-10-14T04:40:32.108Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
-    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
-    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
-    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
-    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
-    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
-    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
-    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7c/0c4760bccf082737ca7ab84a4c2034fcc06b1f21cf3032ea98bd6feb1725/charset_normalizer-3.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9", size = 209609, upload-time = "2025-10-14T04:42:10.922Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a4/69719daef2f3d7f1819de60c9a6be981b8eeead7542d5ec4440f3c80e111/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d", size = 149029, upload-time = "2025-10-14T04:42:12.38Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/21/8d4e1d6c1e6070d3672908b8e4533a71b5b53e71d16828cc24d0efec564c/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608", size = 144580, upload-time = "2025-10-14T04:42:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0a/a616d001b3f25647a9068e0b9199f697ce507ec898cacb06a0d5a1617c99/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc", size = 162340, upload-time = "2025-10-14T04:42:14.892Z" },
-    { url = "https://files.pythonhosted.org/packages/85/93/060b52deb249a5450460e0585c88a904a83aec474ab8e7aba787f45e79f2/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e", size = 159619, upload-time = "2025-10-14T04:42:16.676Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/21/0274deb1cc0632cd587a9a0ec6b4674d9108e461cb4cd40d457adaeb0564/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1", size = 153980, upload-time = "2025-10-14T04:42:17.917Z" },
-    { url = "https://files.pythonhosted.org/packages/28/2b/e3d7d982858dccc11b31906976323d790dded2017a0572f093ff982d692f/charset_normalizer-3.4.4-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3", size = 152174, upload-time = "2025-10-14T04:42:19.018Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ff/4a269f8e35f1e58b2df52c131a1fa019acb7ef3f8697b7d464b07e9b492d/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6", size = 151666, upload-time = "2025-10-14T04:42:20.171Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c9/ec39870f0b330d58486001dd8e532c6b9a905f5765f58a6f8204926b4a93/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88", size = 145550, upload-time = "2025-10-14T04:42:21.324Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8f/d186ab99e40e0ed9f82f033d6e49001701c81244d01905dd4a6924191a30/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1", size = 163721, upload-time = "2025-10-14T04:42:22.46Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b1/6047663b9744df26a7e479ac1e77af7134b1fcf9026243bb48ee2d18810f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf", size = 152127, upload-time = "2025-10-14T04:42:23.712Z" },
-    { url = "https://files.pythonhosted.org/packages/59/78/e5a6eac9179f24f704d1be67d08704c3c6ab9f00963963524be27c18ed87/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318", size = 161175, upload-time = "2025-10-14T04:42:24.87Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/43/0e626e42d54dd2f8dd6fc5e1c5ff00f05fbca17cb699bedead2cae69c62f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c", size = 155375, upload-time = "2025-10-14T04:42:27.246Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/91/d9615bf2e06f35e4997616ff31248c3657ed649c5ab9d35ea12fce54e380/charset_normalizer-3.4.4-cp39-cp39-win32.whl", hash = "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505", size = 99692, upload-time = "2025-10-14T04:42:28.425Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a9/6c040053909d9d1ef4fcab45fddec083aedc9052c10078339b47c8573ea8/charset_normalizer-3.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966", size = 107192, upload-time = "2025-10-14T04:42:29.482Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c6/4fa536b2c0cd3edfb7ccf8469fa0f363ea67b7213a842b90909ca33dd851/charset_normalizer-3.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50", size = 100220, upload-time = "2025-10-14T04:42:30.632Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
 ]
 
 [[package]]
@@ -254,7 +192,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -375,7 +313,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version >= '3.10' and python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -383,7 +321,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -395,8 +333,8 @@ name = "fiobank"
 version = "5.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "pydantic" },
-    { name = "requests" },
     { name = "tenacity", version = "9.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "tenacity", version = "9.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -406,10 +344,68 @@ dev = [
     { name = "mock" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
     { name = "pytest-ruff" },
-    { name = "responses" },
+    { name = "respx" },
     { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "tenacity", specifier = ">=9.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mock", specifier = ">=5.0.1" },
+    { name = "pytest", specifier = ">=7.2.1" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-ruff", specifier = ">=0.4.1" },
+    { name = "respx", specifier = ">=0.21.1" },
+    { name = "ruff", specifier = ">=0.8.4" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -634,13 +630,13 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -655,17 +651,51 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -699,105 +729,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pyyaml"
-version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
-    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
-    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
-    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
-]
-
-[[package]]
-name = "requests"
-version = "2.32.5"
+name = "respx"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "responses"
-version = "0.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]
@@ -922,13 +862,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
Fixes #45.

Implements the one-method transport protocol from the issue discussion, and follows the [note](https://github.com/honzajavorek/fiobank/issues/45#issuecomment-5135385797) to **fully migrate to httpx and drop `requests`** — anyone who wants `requests` (or aiohttp, urllib, a caching layer, …) can supply a custom transport. `AsyncFioBank` keeps its name.

## The seam

A transport does exactly one thing: **GET a URL, return a status code and raw bytes.** Everything else — status interpretation, token sanitization, JSON decoding with `parse_float` — stays in the client, shared by the sync and async variants. It's a `Protocol`, so a custom transport is a handful of lines with no base class to inherit and nothing to register.

```python
class Transport(Protocol):
    def get(self, url: str, params: dict | None = None) -> Response: ...
```

## What changed

- **`fiobank/transports.py`** (new): a `Response` dataclass (status + bytes, with UTF-8 `.text`), the `Transport` / `AsyncTransport` protocols, and the default `HTTPXTransport` / `HTTPXAsyncTransport`.
- **`FioBank` split into `FioBankBase` + sync `FioBank` + new `AsyncFioBank`.** The base holds all the non-I/O logic (`_build_url`, `_check`, `_sanitize`, `_parse_json`, and the existing parsing). The two clients add a `transport=` argument and their own `_request`. tenacity's `@retry` handles the async coroutine with zero extra code.
- **httpx is now the only HTTP dependency; `requests` is dropped.** `httpx.Client` is the default sync transport, `httpx.AsyncClient` the default async one.
- **New public API:** `AsyncFioBank`, `HTTPError`, `Response`, `Transport`, `AsyncTransport`, `HTTPXTransport`, `HTTPXAsyncTransport` — all exported from `fiobank`.
- **Tests:** swapped `responses` → `respx`, added `tests/test_async_fiobank.py` and `tests/test_transports.py` (including a network-free `FakeTransport`). 130 tests pass; `ruff` clean.
- **README:** new *Async* and *HTTP client* sections plus an *HTTP Errors* note.

## Breaking changes (major bump)

- HTTP errors now raise **`fiobank.HTTPError`** (token redacted, with a `status_code` attribute) instead of leaking `requests.HTTPError`. Leaking the transport's exception type is precisely what made the client unpluggable, so this is the deliberate break. `ThrottlingError` is unaffected.
- `requests` is no longer installed by `pip install fiobank`; httpx is. Code that imported `requests` transitively through fiobank, or caught `requests.HTTPError`, needs updating.

I left the version at `5.0.0` so the bump lands in your usual dedicated `release vX.Y.Z` commit — this warrants a major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014BqHRDfE8x25xSqjh5pg3c)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added asynchronous client support for account, transaction, period, and statement operations.
  - Added configurable synchronous and asynchronous HTTP transports, including custom transport support.
  - Added context-manager support for automatic client cleanup.
  - Expanded public exports for clients, transports, responses, and errors.

- **Bug Fixes**
  - Standardized HTTP error handling for non-success responses.
  - Sensitive API tokens are now redacted from error messages.

- **Documentation**
  - Documented asynchronous usage, transport configuration, cleanup, and HTTP error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->